### PR TITLE
Use Pydantic schema for predict endpoint

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -9,6 +9,7 @@
 
 from fastapi import FastAPI, Request
 from fastapi.responses import PlainTextResponse, JSONResponse
+from pydantic import BaseModel
 import time
 
 # Prometheus metrics utilities
@@ -24,6 +25,11 @@ from src.utils.errors import APIError, error_handler
 # Domain-specific code: environment and agent
 from src.env.drone_env import DroneEnv
 from src.agents.ppo_agent import PPOAgent
+
+
+class StateInput(BaseModel):
+    """Schema for the prediction request body."""
+    state: dict
 
 
 # -------------------------------------------------
@@ -66,15 +72,15 @@ async def add_metrics(request: Request, call_next):
 # -------------------------------------------------
 
 @app.post("/predict")
-def predict(state: dict):
+def predict(payload: StateInput):
     """
-    Accepts a state (JSON dictionary) and returns the agent's action.
+    Accepts a payload matching :class:`StateInput` and returns the agent's action.
     Example request: { "state": {...} }
     Example response: { "action": ... }
     """
     logger.info("Received predict request")
     try:
-        action = agent.predict(state)
+        action = agent.predict(payload.state)
     except Exception as e:
         # Wrap raw exceptions in a clean APIError
         raise APIError(f"Prediction failed: {str(e)}", status_code=500)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,10 @@
 from fastapi.testclient import TestClient
-from src.api.app import app
+from src.api.app import app, StateInput
 
 client = TestClient(app)
 
 def test_predict():
-    response = client.post("/predict", json={"state": {"x": 1, "y": 2}})
+    payload = StateInput(state={"x": 1, "y": 2})
+    response = client.post("/predict", json=payload.model_dump())
     assert response.status_code == 200
     assert "action" in response.json()


### PR DESCRIPTION
## Summary
- add `StateInput` Pydantic model to validate `/predict` requests
- update `/predict` to accept `payload: StateInput` and forward `payload.state`
- adjust API test to build payload via the new schema

## Testing
- `pip install fastapi` *(fails: Could not connect to proxy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'env')*


------
https://chatgpt.com/codex/tasks/task_e_68beb3006100832bacecd4b05c86d2f6