### PR TITLE
Pin CI to Python 3.10

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,10 @@ jobs:
         language: [ 'python' ]
     steps:
     - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
     - uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Weighted scores are combined and tested for stability. The Alignment Policy sele
 
 ## Installation
 
-Clone the repository and install dependencies:
+Clone the repository and install dependencies (ensure you are using Python 3.10):
 
     git clone <repo-url>
     cd multi-agent-rl-mapf-drone-system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "multi-agent-rl-mapf-drone-system"
 version = "0.1.0"
 description = "Multi-agent reinforcement learning and MAPF drone coordination system"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.12"
 license = { file = "LICENSE" }
 
 authors = [


### PR DESCRIPTION
## Summary
- ensure CodeQL workflow uses Python 3.10
- document Python 3.10 requirement and restrict package metadata

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement gym==0.26.2)*
- `pytest -q` *(fails: pytest: error: unrecognized arguments: --cov=src --cov-report=term-missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf57276efc832bb347daa3c468bae5