### PR TITLE
chore: switch to gymnasium and update torch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "multi-agent-rl-mapf-drone-system"
 version = "0.1.0"
 description = "Multi-agent reinforcement learning and MAPF drone coordination system"
 readme = "README.md"
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.9,<3.13"
 license = { file = "LICENSE" }
 
 authors = [
@@ -18,8 +18,8 @@ authors = [
 
 dependencies = [
     # Core ML stack
-    "gym==0.26.2",
-    "torch==2.0.1",
+    "gymnasium>=0.29.1",
+    "torch==2.2.2",
     "numpy==1.24.3",
 
     # API and monitoring

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Unified dependencies for multi-agent-rl-mapf-drone-system
 
 # Core ML stack
-gym==0.26.2
-torch==2.0.1
+gymnasium>=0.29.1
+torch==2.2.2
 numpy==1.24.3
 matplotlib==3.7.1
 


### PR DESCRIPTION
## Summary
- switch dependency from gym to gymnasium
- bump torch to 2.2.2
- allow python 3.12 in pyproject

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement gymnasium>=0.29.1)*
- `PYTHONPATH=src pytest -q -o addopts=` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68bf66e06000832b90834b2dbac81254