### PR TITLE
Fix CI: migrate to gymnasium, pin httpx, install package in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,5 +11,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy project code
 COPY . .
 
+# Install the project itself so the src/ layout is importable
+# (main, integrity_validators, env, agents, ...) exactly as in CI.
+RUN pip install --no-cache-dir -e .
+
 # Default command runs training
-CMD ["python", "main.py"]
+CMD ["python", "-m", "main"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,10 @@ dev = [
     "pytest==7.4.0",
     "pytest-cov==4.1.0",
     "matplotlib==3.7.1",
-    "jupyter==1.0.0"
+    "jupyter==1.0.0",
+    # fastapi.testclient needs httpx. starlette 0.36.x (pinned by fastapi
+    # 0.110.0) passes app= to httpx.Client, which httpx removed in 0.28.
+    "httpx>=0.27.0,<0.28"
 ]
 
 [tool.setuptools.package-dir]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ prometheus-client==0.20.0
 pytest==7.4.0
 pytest-cov==4.1.0
 jupyter==1.0.0
+# fastapi.testclient needs httpx. starlette 0.36.x (pinned by fastapi 0.110.0)
+# passes app= to httpx.Client, which httpx removed in 0.28.
+httpx>=0.27.0,<0.28
 
 # ------------------------------
 # Developer Note:

--- a/src/env/drone_env.py
+++ b/src/env/drone_env.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Tuple, Dict, Any
 
 import numpy as np
-import gym
-from gym import spaces
+import gymnasium as gym
+from gymnasium import spaces
 
 try:  # pragma: no cover - optional dependency
     import yaml  # type: ignore
@@ -26,7 +26,7 @@ class DroneEnv(gym.Env):
         Path to the YAML configuration file. If omitted, uses ``configs/env.yaml``.
     """
 
-    metadata = {"render.modes": ["human"]}
+    metadata = {"render_modes": ["human"]}
 
     def __init__(self, config_path: str | Path = "configs/env.yaml"):
         super().__init__()
@@ -37,10 +37,21 @@ class DroneEnv(gym.Env):
         self.max_steps: int = int(self.config.get("max_steps", 100))
 
         # Observation: [x, y, goal_x, goal_y, steps_remaining]
+        # Bounds are per-dimension: the four coordinates are clamped to the grid,
+        # while steps_remaining counts down from max_steps. A single scalar bound
+        # would put every steps_remaining > grid_size outside the declared space.
         self.observation_space = spaces.Box(
-            low=0.0,
-            high=float(self.grid_size),
-            shape=(5,),
+            low=np.zeros(5, dtype=np.float32),
+            high=np.array(
+                [
+                    self.grid_size - 1,
+                    self.grid_size - 1,
+                    self.grid_size - 1,
+                    self.grid_size - 1,
+                    self.max_steps,
+                ],
+                dtype=np.float32,
+            ),
             dtype=np.float32,
         )
 


### PR DESCRIPTION
## Problem

- `Run Tests` and `Docker Build` are both red on `main`; only CodeQL is green.
- `src/env/drone_env.py` imports `gym`, but the declared dependency is `gymnasium`. The import raises, `tests/conftest.py` swallows it and substitutes a stub `DroneEnv` with no `reset()`, so the real environment is never exercised and the failure surfaces as a confusing `AttributeError`.
- httpx is never declared, so it floated to 0.28.1. starlette 0.36.x (pinned by fastapi 0.110.0) passes `app=` to `httpx.Client`, which httpx removed in 0.28, breaking every `TestClient` construction.
- `docker/Dockerfile` never runs `pip install -e .`, so the `src/` layout is not importable and collection dies on `main` and `integrity_validators`.

## Fix

- **gymnasium migration**: `import gym` becomes `import gymnasium as gym` in `src/env/drone_env.py`, matching the dependency already declared in `requirements.txt` and `pyproject.toml`. Metadata key updated to the gymnasium spelling `render_modes`. The env was already written to the gymnasium API (5-tuple `step`, `(obs, info)` `reset`), so no behavior change.
- **httpx bound**: declared `httpx>=0.27.0,<0.28` in both `requirements.txt` and the `dev` extra, the version range compatible with the pinned starlette.
- **Docker**: added `pip install --no-cache-dir -e .` so the image matches what `test.yml` does, and corrected `CMD` to `python -m main`; the old `python main.py` pointed at a path that does not exist at the image root under the `src/` layout.
- **Observation space bounds**: with the real environment finally running, one masked bug surfaced. The Box declared a single scalar `high` of `grid_size` across all five dimensions, but `steps_remaining` counts down from `max_steps` (200 against a `grid_size` of 20), so every step reported a spurious `observation out of bounds` drift error. Bounds are now per-dimension.

## Tests

Verified in the `python:3.10-slim` CI image, running both jobs' exact commands.

- [x] Happy path: `docker run --rm drone-rl python -m pytest -q` (the `Docker Build` job command), 6 passed
- [x] Happy path: `docker run --rm drone-rl pytest -v` (the `Run Tests` job command), 6 passed
- [x] Integration: `test_train_and_inference` and `test_integration_workflow` now run the real `DroneEnv` and `PPOAgent` rather than conftest stubs
- [x] Unit: `test_env_integrity_validator_clean_run` passes against the real env, confirming a legal hover produces no integrity errors
- [x] Edge cases: `reset()` observation `[0, 0, 19, 19, 200]` confirmed inside `observation_space`; previously outside it

Coverage moved from 38% to 85% because the real modules now import instead of stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
