### PR TITLE
Rewrite README: correct inaccurate claims, add a sharp chrome-silver diagram set

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ So this repo attaches a validator to both sides of the loop and makes every step
 
 The distinction earns its keep because the two need different responses. Drift means a bound is wrong or a distribution is moving, so you widen, retrain, or investigate. Hallucination means the output space itself was violated, so you stop.
 
+<p align="center">
+  <img src="assets/drift-vs-hallucination.svg" alt="Drift against hallucination. Drift is a value of the right kind landing outside its declared range, shown as 200 beyond a bound of 20. Hallucination is a value that was never in the space, shown as action 999 detached from a five slot discrete space." width="100%">
+</p>
+
 **This is not a theoretical feature.** Getting CI green on this repo surfaced a bug the validators had been reporting correctly the whole time while nobody was reading them. `observation_space` declared a single scalar upper bound of `grid_size` across all five dimensions, but the fifth dimension counts down from `max_steps`. Under the shipped config that is 200 against a bound of 20, so **every step of every episode raised an observation drift error**. The validator was right. The declared space was wrong.
 
 ---

--- a/README.md
+++ b/README.md
@@ -85,57 +85,74 @@ The validators report and continue; they do not halt a run. That is a deliberate
 
 ## Architecture
 
+The control loop is small. The validators hang off both halves of it, and everything they find funnels into one counter.
+
 ```mermaid
-flowchart LR
-    CFG["configs/env.yaml<br/>grid 20x20, 200 steps"]
+%%{init: {"theme":"base","themeVariables":{"fontSize":"17px","fontFamily":"ui-sans-serif, system-ui, sans-serif","lineColor":"#64748b"},"flowchart":{"curve":"basis","nodeSpacing":55,"rankSpacing":65,"padding":14}}}%%
+flowchart TB
+    CFG["<b>configs/env.yaml</b><br/>grid 20x20, 200 max steps"]
 
-    subgraph ENV["DroneEnv (gymnasium)"]
-        RESET["reset() to obs, info"]
-        STEP["step(a) to obs, reward,<br/>terminated, truncated, info"]
-        IV["IntegrityValidator<br/>obs / action / reward"]
+    subgraph ENV["&nbsp;DroneEnv&nbsp; (gymnasium)&nbsp;"]
+        direction LR
+        STEP["<b>reset()</b> and <b>step(action)</b><br/>obs, reward, terminated,<br/>truncated, info"]
+        IV["<b>IntegrityValidator</b><br/>observation in space?<br/>action legal? reward finite?"]
+        STEP ==> IV
     end
 
-    subgraph AGENT["PPOAgent (PyTorch)"]
-        NET["PPOPolicy<br/>shared 64, policy head + value head"]
-        PIV["PolicyIntegrityValidator<br/>probs / value / action"]
+    subgraph AGENT["&nbsp;PPOAgent&nbsp; (PyTorch)&nbsp;"]
+        direction LR
+        NET["<b>PPOPolicy</b><br/>shared Linear(5,64) + ReLU<br/>policy head, value head"]
+        PIV["<b>PolicyIntegrityValidator</b><br/>probs sum to 1? value finite?<br/>action in space?"]
+        NET ==> PIV
     end
 
-    STATS["IntegrityStats<br/>drift vs hallucination tallies"]
-    API["FastAPI<br/>/predict  /metrics  /healthz"]
-    PROM["Prometheus + Grafana"]
+    STATS["<b>IntegrityStats</b><br/>drift vs hallucination,<br/>as a rate per step"]
+    API["<b>FastAPI</b><br/>/predict &nbsp;/metrics &nbsp;/healthz"]
+    OPS["<b>Prometheus + Grafana</b>"]
 
     CFG ==> ENV
-    RESET ==> NET
-    STEP ==> IV
-    IV ==> STATS
-    NET ==> PIV
-    PIV ==> STATS
-    NET ==> STEP
+    ENV == "observation" ==> AGENT
+    AGENT == "action" ==> ENV
+    IV -.-> STATS
+    PIV -.-> STATS
     AGENT ==> API
-    API ==> PROM
+    API ==> OPS
 
-    classDef env fill:#0d1b2a,stroke:#00d4ff,stroke-width:3px,color:#00d4ff
-    classDef agent fill:#1b263b,stroke:#b537f2,stroke-width:3px,color:#b537f2
-    classDef guard fill:#1b263b,stroke:#ff006e,stroke-width:3px,color:#ff006e
-    classDef ops fill:#0d1b2a,stroke:#39ff14,stroke-width:2px,color:#39ff14
+    classDef cfg fill:#0d1b2a,stroke:#38bdf8,stroke-width:2px,color:#e2e8f0
+    classDef core fill:#132a3f,stroke:#00d4ff,stroke-width:2px,color:#e2e8f0
+    classDef brain fill:#1b263b,stroke:#b537f2,stroke-width:2px,color:#e2e8f0
+    classDef guard fill:#2a1220,stroke:#ff006e,stroke-width:3px,color:#ffd7e6
+    classDef ops fill:#0d1b2a,stroke:#39ff14,stroke-width:2px,color:#e2e8f0
 
-    class RESET,STEP,CFG env
-    class NET agent
+    class CFG cfg
+    class STEP core
+    class NET brain
     class IV,PIV,STATS guard
-    class API,PROM ops
+    class API,OPS ops
+
+    style ENV fill:#0a1422,stroke:#00d4ff,stroke-width:2px,color:#7dd3fc
+    style AGENT fill:#0a1422,stroke:#b537f2,stroke-width:2px,color:#d8b4fe
 ```
 
-<p align="center">
-  <img src="architecture/drone_high_lv_system_design.png" alt="High level system design" width="80%">
-</p>
+The three pink boxes are the subject of this repository. Everything else is scaffolding around them.
 
 <details>
-<summary><b>Low level design and reward pattern reference</b></summary>
+<summary><b>Original design diagrams</b> (wide panoramas, click through for full size)</summary>
 <br/>
 
+These are the hand-drawn system designs from the original build. They are very wide, so they read poorly inline; open each one full size.
+
 <p align="center">
-  <img src="architecture/drone_low_lv_system_design.png" alt="Low level system design" width="80%"><br/><br/>
-  <img src="architecture/drones_matrix_RL.png" alt="Reward pattern reference" width="80%">
+  <a href="architecture/drone_high_lv_system_design.png"><img src="architecture/drone_high_lv_system_design.png" alt="High level system design" width="100%"></a>
+  <br/><em>High level design.</em> <a href="architecture/drone_high_lv_system_design.png">Open full size</a>
+  <br/><br/>
+  <a href="architecture/drone_low_lv_system_design.png"><img src="architecture/drone_low_lv_system_design.png" alt="Low level system design" width="100%"></a>
+  <br/><em>Low level design.</em> <a href="architecture/drone_low_lv_system_design.png">Open full size</a>
+</p>
+
+<p align="center">
+  <img src="architecture/drones_matrix_RL.png" alt="Reward pattern reference" width="88%">
+  <br/><em>Reward pattern reference: event-based against continuous shaping, on both the self and interaction axes.</em>
 </p>
 
 Written specs live in [`architecture/low_level_design.txt`](architecture/low_level_design.txt) and [`architecture/summary.md`](architecture/summary.md).

--- a/README.md
+++ b/README.md
@@ -87,52 +87,9 @@ The validators report and continue; they do not halt a run. That is a deliberate
 
 The control loop is small. The validators hang off both halves of it, and everything they find funnels into one counter.
 
-```mermaid
-%%{init: {"theme":"base","themeVariables":{"fontSize":"17px","fontFamily":"ui-sans-serif, system-ui, sans-serif","lineColor":"#64748b"},"flowchart":{"curve":"basis","nodeSpacing":55,"rankSpacing":65,"padding":14}}}%%
-flowchart TB
-    CFG["<b>configs/env.yaml</b><br/>grid 20x20, 200 max steps"]
-
-    subgraph ENV["&nbsp;DroneEnv&nbsp; (gymnasium)&nbsp;"]
-        direction LR
-        STEP["<b>reset()</b> and <b>step(action)</b><br/>obs, reward, terminated,<br/>truncated, info"]
-        IV["<b>IntegrityValidator</b><br/>observation in space?<br/>action legal? reward finite?"]
-        STEP ==> IV
-    end
-
-    subgraph AGENT["&nbsp;PPOAgent&nbsp; (PyTorch)&nbsp;"]
-        direction LR
-        NET["<b>PPOPolicy</b><br/>shared Linear(5,64) + ReLU<br/>policy head, value head"]
-        PIV["<b>PolicyIntegrityValidator</b><br/>probs sum to 1? value finite?<br/>action in space?"]
-        NET ==> PIV
-    end
-
-    STATS["<b>IntegrityStats</b><br/>drift vs hallucination,<br/>as a rate per step"]
-    API["<b>FastAPI</b><br/>/predict &nbsp;/metrics &nbsp;/healthz"]
-    OPS["<b>Prometheus + Grafana</b>"]
-
-    CFG ==> ENV
-    ENV == "observation" ==> AGENT
-    AGENT == "action" ==> ENV
-    IV -.-> STATS
-    PIV -.-> STATS
-    AGENT ==> API
-    API ==> OPS
-
-    classDef cfg fill:#0d1b2a,stroke:#38bdf8,stroke-width:2px,color:#e2e8f0
-    classDef core fill:#132a3f,stroke:#00d4ff,stroke-width:2px,color:#e2e8f0
-    classDef brain fill:#1b263b,stroke:#b537f2,stroke-width:2px,color:#e2e8f0
-    classDef guard fill:#2a1220,stroke:#ff006e,stroke-width:3px,color:#ffd7e6
-    classDef ops fill:#0d1b2a,stroke:#39ff14,stroke-width:2px,color:#e2e8f0
-
-    class CFG cfg
-    class STEP core
-    class NET brain
-    class IV,PIV,STATS guard
-    class API,OPS ops
-
-    style ENV fill:#0a1422,stroke:#00d4ff,stroke-width:2px,color:#7dd3fc
-    style AGENT fill:#0a1422,stroke:#b537f2,stroke-width:2px,color:#d8b4fe
-```
+<p align="center">
+  <img src="assets/architecture.svg" alt="PPO control loop: configs/env.yaml feeds DroneEnv, which exchanges observations and actions with PPOAgent. An IntegrityValidator sits inside the environment and a PolicyIntegrityValidator inside the agent; both report into IntegrityStats. The agent is served behind FastAPI, scraped by Prometheus and Grafana." width="100%">
+</p>
 
 The three pink boxes are the subject of this repository. Everything else is scaffolding around them.
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@
 <a href="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/docker.yml"><img src="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/docker.yml/badge.svg?branch=main" alt="Docker Build"/></a>
 <a href="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/codeql-analysis.yml"><img src="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/codeql-analysis.yml/badge.svg?branch=main" alt="CodeQL"/></a>
 
-<img alt="python 3.10" src="https://img.shields.io/badge/python-3.10-d7dee7?style=flat-square&labelColor=12161d">
-<img alt="PPO in PyTorch 2.2.2" src="https://img.shields.io/badge/PPO-PyTorch_2.2.2-8a95a5?style=flat-square&labelColor=12161d">
-<img alt="env gymnasium" src="https://img.shields.io/badge/env-gymnasium-8a95a5?style=flat-square&labelColor=12161d">
-<img alt="tests 6 passing" src="https://img.shields.io/badge/tests-6_passing-8a95a5?style=flat-square&labelColor=12161d">
-<img alt="coverage 85 percent" src="https://img.shields.io/badge/coverage-85%25-8a95a5?style=flat-square&labelColor=12161d">
-<img alt="license Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-8a95a5?style=flat-square&labelColor=12161d">
+<img alt="python 3.10" src="https://img.shields.io/badge/python-3.10-dfe3e0?style=flat-square&labelColor=0d1410">
+<img alt="PPO in PyTorch 2.2.2" src="https://img.shields.io/badge/PPO-PyTorch_2.2.2-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="env gymnasium" src="https://img.shields.io/badge/env-gymnasium-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="tests 6 passing" src="https://img.shields.io/badge/tests-6_passing-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="coverage 85 percent" src="https://img.shields.io/badge/coverage-85%25-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="license Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-8f9491?style=flat-square&labelColor=0d1410">
 
 <br/><br/>
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,34 @@ Moves clamp at the grid edge, so an illegal move is absorbed rather than rejecte
 
 **Reward**: `+10.0` on reaching the goal, `-1.0` per step otherwise. `terminated` on goal, `truncated` at `max_steps`. The agent starts at the origin and the goal sits at the far corner, so the shortest path under this config is 38 moves.
 
+That shipped reward is deliberately spiky: the goal bonus is an event, not a gradient. It is the top left quadrant below, and it is the cheapest thing that works for a single drone. Once more than one drone shares the grid, the quadrant matters, because a spike is exactly what a policy learns to farm.
+
+<p align="center">
+  <img src="assets/reward-shaping.svg" alt="A two by two matrix. Self alignment on one axis and peer interaction on the other, each either event based or continuous. Continuous on both axes is the stable quadrant; the other three invite goal hacking on one or both sides." width="100%">
+</p>
+
+<details>
+<summary>Same diagram as text</summary>
+
+```text
+                          PEER INTERACTION
+                  event based            continuous
+                  +Y if coop_event       g(coop_quality)
+  SELF
+  ALIGNMENT
+  event based     Spiky on both axes     Spiky on self only
+  +X if goal_met  unstable, goal         cooperation looks good,
+                  hacking likely         solo flight degrades
+
+  continuous      Spiky on peers only    Continuous on both axes
+  f(alignment)    flies itself well,     the stable quadrant,
+                  competes with peers    no spike left to chase
+```
+
+</details>
+
+This is a design reference for the multi-drone roadmap, not something `src/` implements today.
+
 ---
 
 ## The PPO agent

--- a/README.md
+++ b/README.md
@@ -1,148 +1,322 @@
-# Multi-Agent RL MAPF Drone System
-**Instant-alignment drone AI for safe, adaptive, real-time flight control.**
+<div align="center">
 
-Production-ready multi agent drone AI with PPO, FastAPI backend, Docker deployment, and monitoring.
+<b><font size="6">Multi-Agent RL MAPF Drone Navigation</font></b>
 
----
+<br/>
 
-## Overview  
-This system combines Reinforcement Learning (RL), Multi-Agent Path Finding (MAPF), and real-time alignment scoring to control drones safely. Instead of waiting for delayed success signals, the system scores each action instantly against internal principles (the “Constitution”) so it can act safely and efficiently in real time.
+<a href="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/test.yml"><img src="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/test.yml/badge.svg?branch=main" alt="Run Tests"/></a>
+<a href="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/docker.yml"><img src="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/docker.yml/badge.svg?branch=main" alt="Docker Build"/></a>
+<a href="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/codeql-analysis.yml"><img src="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/codeql-analysis.yml/badge.svg?branch=main" alt="CodeQL"/></a>
 
-The architecture integrates:  
-- A custom drone environment  
-- A PPO agent in PyTorch  
-- Alignment scoring for safety and smoothness  
-- API endpoints for predictions, health, and metrics  
-- Monitoring hooks for production environments  
+<img alt="python 3.10" src="https://img.shields.io/badge/python-3.10-0ea5e9?style=flat-square&labelColor=0f172a">
+<img alt="PPO in PyTorch 2.2.2" src="https://img.shields.io/badge/PPO-PyTorch_2.2.2-164e63?style=flat-square&labelColor=0f172a">
+<img alt="env gymnasium" src="https://img.shields.io/badge/env-gymnasium-164e63?style=flat-square&labelColor=0f172a">
+<img alt="tests 6 passing" src="https://img.shields.io/badge/tests-6_passing-164e63?style=flat-square&labelColor=0f172a">
+<img alt="coverage 85 percent" src="https://img.shields.io/badge/coverage-85%25-164e63?style=flat-square&labelColor=0f172a">
+<img alt="license Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-164e63?style=flat-square&labelColor=0f172a">
 
----
+<br/><br/>
 
-## System Architecture
+<strong>A PPO drone-navigation agent that validates its own policy outputs at every step.</strong><br/>
+The interesting part is not the controller. It is the layer watching the controller,<br/>
+which separates <em>drift</em>, a number sliding out of its declared range, from<br/>
+<em>hallucination</em>, an output that was never legal to begin with.
 
-### Core Agents
-- **Ingestion Agent**  
-  Collects raw sensor data (camera, GPS, IMU, barometer) at fixed frequency and queues it.  
+<br/>
 
-- **Preprocess Agent**  
-  Filters and compresses raw inputs into compact features.  
+<code>observe -> policy -> validate -> act</code>
 
-- **Prediction Agent**  
-  Uses the PPO policy to select the drone’s next action (hover, climb, move, turn).  
-
-### Alignment Scoring
-Each action is scored instantly against values:  
-- Maintain safety margins  
-- Save energy  
-- Move smoothly  
-
-Weighted scores are combined and tested for stability. The Alignment Policy selects the safest, most stable action.  
-
-### Safety and Oversight
-- **Safety Controller** – vetoes unsafe actions (for example, entering a no-fly zone).  
-- **Supervisor** – starts/stops agents, restarts failures, quarantines unstable modules.  
+</div>
 
 ---
 
-## Repository Structure
-    multi-agent-rl-mapf-drone-system/
-    ├── configs/              # Training and environment configs
-    ├── docker/               # Docker and Kubernetes deployment files
-    ├── docs/                 # Architecture and deployment documentation
-    ├── monitoring/           # Prometheus, Grafana, Alertmanager configs
-    ├── scripts/              # Helper scripts (run, train, deploy)
-    ├── src/                  # Source code (agents, API, env, utils)
-    └── tests/                # Unit, integration, and load tests
+## Why the validators are the point
+
+A policy network fails quietly. It returns a number of the right type, in the right shape, at the right time, and that number is wrong. Nothing raises. A type checker sees a `float`. The training loop keeps going and the loss curve still looks reasonable.
+
+So this repo attaches a validator to both sides of the loop and makes every step answer two separate questions:
+
+| | question | example | means |
+|---|---|---|---|
+| **Drift** | Is this value still inside the range it declared? | An observation outside `observation_space`, a non-finite reward, action probabilities that stop summing to 1 | a bound was crossed |
+| **Hallucination** | Was this output ever legal? | Action index `999` against a `Discrete(5)` space | a value was invented |
+
+The distinction earns its keep because the two need different responses. Drift means a bound is wrong or a distribution is moving, so you widen, retrain, or investigate. Hallucination means the output space itself was violated, so you stop.
+
+`IntegrityStats` tallies both across a run and prints a report at the end of training and of inference, so a run that completed is not automatically a run that was clean.
+
+**This is not a theoretical feature.** Getting CI green on this repo surfaced a bug the validators had been reporting correctly the whole time while nobody was reading them. `observation_space` declared a single scalar upper bound of `grid_size` across all five dimensions, but the fifth dimension counts down from `max_steps`. Under the shipped config that is 200 against a bound of 20, so **every step of every episode raised an observation drift error**. The validator was right. The declared space was wrong.
 
 ---
 
-## System Design Files
-- High-Level Diagram: `drone_high_lv_system_design.png`  
-- Low-Level Diagram: `drone_low_lv_system_design.png`  
-- Reward Patterns Reference: `drones_matrix_RL.png`  
-- Detailed Specs: `low_level_design/`  
+## Architecture
+
+```mermaid
+flowchart LR
+    CFG["configs/env.yaml<br/>grid 20x20, 200 steps"]
+
+    subgraph ENV["DroneEnv (gymnasium)"]
+        RESET["reset() to obs, info"]
+        STEP["step(a) to obs, reward,<br/>terminated, truncated, info"]
+        IV["IntegrityValidator<br/>obs / action / reward"]
+    end
+
+    subgraph AGENT["PPOAgent (PyTorch)"]
+        NET["PPOPolicy<br/>shared 64, policy head + value head"]
+        PIV["PolicyIntegrityValidator<br/>probs / value / action"]
+    end
+
+    STATS["IntegrityStats<br/>drift vs hallucination tallies"]
+    API["FastAPI<br/>/predict  /metrics  /healthz"]
+    PROM["Prometheus + Grafana"]
+
+    CFG ==> ENV
+    RESET ==> NET
+    STEP ==> IV
+    IV ==> STATS
+    NET ==> PIV
+    PIV ==> STATS
+    NET ==> STEP
+    AGENT ==> API
+    API ==> PROM
+
+    classDef env fill:#0d1b2a,stroke:#00d4ff,stroke-width:3px,color:#00d4ff
+    classDef agent fill:#1b263b,stroke:#b537f2,stroke-width:3px,color:#b537f2
+    classDef guard fill:#1b263b,stroke:#ff006e,stroke-width:3px,color:#ff006e
+    classDef ops fill:#0d1b2a,stroke:#39ff14,stroke-width:2px,color:#39ff14
+
+    class RESET,STEP,CFG env
+    class NET agent
+    class IV,PIV,STATS guard
+    class API,PROM ops
+```
+
+<p align="center">
+  <img src="architecture/drone_high_lv_system_design.png" alt="High level system design" width="80%">
+</p>
+
+<details>
+<summary><b>Low level design and reward pattern reference</b></summary>
+<br/>
+
+<p align="center">
+  <img src="architecture/drone_low_lv_system_design.png" alt="Low level system design" width="80%"><br/><br/>
+  <img src="architecture/drones_matrix_RL.png" alt="Reward pattern reference" width="80%">
+</p>
+
+Written specs live in [`architecture/low_level_design.txt`](architecture/low_level_design.txt) and [`architecture/summary.md`](architecture/summary.md).
+
+</details>
 
 ---
 
-## Installation
+## The environment
 
-Clone the repository and install dependencies (ensure you are using Python 3.10):
+A grid world, deliberately small, so the validator layer is the thing under test rather than the control problem.
 
-    git clone <repo-url>
-    cd multi-agent-rl-mapf-drone-system
-    pip install -r requirements.txt
+**Observation**, a `Box` of shape `(5,)`, `float32`:
 
-Or, with pyproject.toml:
+| index | field | range |
+|---|---|---|
+| 0, 1 | drone `x`, `y` | `0` to `grid_size - 1` |
+| 2, 3 | goal `x`, `y` | `0` to `grid_size - 1` |
+| 4 | `steps_remaining` | `0` to `max_steps` |
 
-    pip install .
+Bounds are per-dimension, for the reason described above. One scalar bound cannot describe both a coordinate and a step counter.
+
+**Action**, `Discrete(5)`: `0` hover, `1` up, `2` down, `3` left, `4` right. Moves clamp at the grid edge, so an illegal move is absorbed rather than rejected.
+
+**Reward**: `+10.0` on reaching the goal, `-1.0` per step otherwise. `terminated` on goal, `truncated` at `max_steps`.
+
+**Config** ([`configs/env.yaml`](configs/env.yaml)):
+
+```yaml
+grid_size: 20
+num_drones: 10
+obstacle_density: 0.1
+max_steps: 200
+```
 
 ---
 
-## Usage
+## Scope and status
 
-Train the model:
+Worth reading before the deployment sections. The repository name is older than the code.
 
-    python src/main.py --config configs/train.yaml
+| capability | status |
+|---|---|
+| Single-drone PPO navigation on a grid | **Implemented**, trains and runs |
+| Integrity validators, drift and hallucination classification | **Implemented**, covered by tests |
+| `IntegrityStats` reporting across a run | **Implemented** |
+| FastAPI service, `/metrics` and `/healthz` | **Implemented** |
+| Docker image, Compose, Kubernetes manifests, Prometheus and Grafana config | **Implemented** as configuration |
+| `/predict` end to end | **Broken**, see Known gaps |
+| Multi-agent, more than one drone | **Not implemented**. `num_drones` is read into an attribute and never used; the env tracks a single position vector |
+| MAPF, multi-agent path finding | **Not implemented**. No conflict resolution, no reservation table, no joint planner |
+| Obstacles | **Not implemented**. `obstacle_density` is read and never used |
+| Ingestion, Preprocess and Prediction agents; Safety Controller; Supervisor | **Design only**, described in [`architecture/summary.md`](architecture/summary.md), no code in `src/` |
 
-Run the API server:
+The multi-agent and MAPF pieces are the roadmap the name points at, not a description of `src/`.
 
-    uvicorn src.api.app:app --reload
+### Known gaps
 
-Example request:
+**`/predict` currently rejects every input.** The request schema declares `state: dict`, while `PPOAgent.predict` calls `torch.tensor(state)` and needs a numeric sequence. No body satisfies both:
 
-    curl -X POST http://localhost:8000/predict          -H "Content-Type: application/json"          -d '{"state": {"drone": [0,0], "goal": [5,5]}}'
+```
+{"state": [0,0,19,19,200]}   ->  422  pydantic: "Input should be a valid dictionary"
+{"state": {"x": 1, "y": 2}}  ->  500  "Prediction failed: must be real number, not dict"
+```
 
-Example response:
+`tests/test_api.py` does not catch this, because it replaces `PPOAgent` with a stub that returns a constant. The fix is to agree on one contract, most naturally the 5-number observation vector, then make the schema and the agent match.
 
-    {"action": "move_up"}
+---
+
+## Quickstart
+
+Python 3.10. The editable install is required rather than optional: the project uses a `src/` layout, and the tests import `main`, `env` and `agents` as top-level modules.
+
+```bash
+git clone https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation.git
+cd multi-agent-rl-mapf-drone-navigation
+pip install -r requirements.txt
+pip install -e .
+```
+
+Train, then run a short inference rollout:
+
+```bash
+python -m main
+```
+
+That trains for 10 episodes, writes `models/ppo_drone.pt`, and prints an integrity report for each phase:
+
+```
+Starting training for 10 episodes...
+Episode 1, total reward=-200.00
+...
+Episode 10, total reward=-200.00
+Model saved to models/ppo_drone.pt
+[Training Integrity Report] Steps=2000
+  - Drift errors: 0 (0.00% of steps)
+  - Hallucination errors: 0 (0.00% of steps)
+Step 1: action=up, reward=-1.00
+...
+Total reward over 5 steps = -5.00
+[Inference Integrity Report] Steps=5
+  - Drift errors: 0 (0.00% of steps)
+  - Hallucination errors: 0 (0.00% of steps)
+```
+
+Those two zeroes are the whole point of the section above. Before the observation-space bounds were fixed, that same run reported a drift error on all 2000 of 2000 steps. Ten episodes on a 20x20 grid is far too short to reach the goal, which is why every episode returns the `-200.00` floor; the run demonstrates the validator layer, not convergence.
+
+Serve the API:
+
+```bash
+uvicorn src.api.app:app --reload
+```
+
+```bash
+curl http://localhost:8000/healthz
+# {"status":"ok"}
+```
+
+`/predict` is reachable but not yet usable. See Known gaps.
+
+---
+
+## API
+
+| method | path | purpose | status |
+|---|---|---|---|
+| `POST` | `/predict` | Greedy action from the loaded policy | Reachable, contract broken |
+| `GET` | `/metrics` | Prometheus exposition format | Working |
+| `GET` | `/healthz` | Liveness and readiness probe | Working |
+
+Weights load at startup from `models/ppo_drone.pt`. If that file is absent the service logs a warning and serves an untrained policy rather than refusing to start, which is the right call for a probe endpoint and the wrong one for a prediction endpoint.
+
+Every request passes through middleware recording `REQUEST_COUNT` and `REQUEST_LATENCY` by method and endpoint. Notes in [`docs/API.md`](docs/API.md).
+
+---
+
+## Testing
+
+```bash
+pytest -v
+pytest --cov=src --cov-report=term-missing
+```
+
+| file | what it covers |
+|---|---|
+| `tests/test_integrity.py` | A legal step produces no integrity errors; the policy validator flags negative probabilities, non-finite values and out-of-space actions |
+| `tests/test_training.py` | Train, save and reload, then a short greedy rollout |
+| `tests/test_integration.py` | Environment and agent wired together |
+| `tests/test_api.py` | `/predict` against a stubbed agent |
+| `tests/test_load.py` | Repeated stepping under pressure |
+
+Current state on `main`: 6 passing, 85 percent line coverage.
+
+**One caveat worth knowing.** `tests/conftest.py` catches any import failure of the real `DroneEnv` and substitutes a stub. That is why a missing dependency once surfaced as `AttributeError: 'DroneEnv' object has no attribute 'reset'` instead of an import error, and why coverage sat at 38 percent while appearing to exercise the environment. The stub is still in place.
 
 ---
 
 ## Deployment
 
-Using Docker:
+```bash
+docker build -t drone-rl -f docker/Dockerfile .
+docker run --rm drone-rl python -m pytest -q
+```
 
-    docker build -t drone-system -f docker/Dockerfile.prod .
-    docker run -p 8080:8080 drone-system
+```bash
+docker compose -f docker/docker-compose.yml up
+```
 
-Using Kubernetes:
+```bash
+kubectl apply -f docker/k8s/
+```
 
-    kubectl apply -f docker/k8s/deployment.yaml
-    kubectl apply -f docker/k8s/service.yaml
+`docker/Dockerfile` installs the project editable, so the `src/` layout resolves the way it does in CI. `docker/Dockerfile.prod` takes a different route and copies `src/` to the image root; note that `src/api/app.py` imports through the `src.` prefix, so the prod image suits the training entrypoint rather than the API. Notes in [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).
 
 ---
 
 ## Monitoring
-- Metrics: `/metrics` endpoint (Prometheus)  
-- Health: `/healthz` endpoint (Kubernetes probes)  
-- Dashboard: `monitoring/grafana-dashboard.json`  
-- Alerting: `monitoring/alertmanager.yml`  
 
-Key Grafana panels:  
-- Request latency (p95)  
-- Requests by endpoint  
-- Training reward distribution  
-- Error rate  
+| surface | file |
+|---|---|
+| Prometheus scrape config | [`monitoring/prometheus.yml`](monitoring/prometheus.yml) |
+| Grafana dashboard | [`monitoring/grafana-dashboard.json`](monitoring/grafana-dashboard.json) |
+| Alertmanager routes | [`monitoring/alertmanager.yml`](monitoring/alertmanager.yml) |
+
+Panels cover request latency p95, requests by endpoint, training reward distribution and error rate.
 
 ---
 
-## Tests
+## Repository layout
 
-Run all tests:
-
-    pytest --cov=src
-
-Covers:  
-- Unit tests (`tests/test_api.py`, `tests/test_training.py`)  
-- Integrity tests (`tests/test_integrity.py`)  
-- Integration tests (`tests/test_integration.py`)  
-- Load tests (`tests/test_load.py`)  
+```
+multi-agent-rl-mapf-drone-navigation/
+├── architecture/        # Design diagrams, low level specs, interview summary
+├── configs/             # env.yaml, env-prod.yaml, train.yaml
+├── docker/              # Dockerfile, Dockerfile.prod, compose, k8s manifests
+├── docs/                # API, ARCHITECTURE, DEPLOYMENT
+├── monitoring/          # Prometheus, Grafana, Alertmanager
+├── scripts/             # train.sh, run_server.sh, deploy.sh
+├── src/
+│   ├── agents/          # ppo_agent.py: PPOPolicy, PPOAgent
+│   ├── api/             # app.py: FastAPI service
+│   ├── env/             # drone_env.py: DroneEnv
+│   ├── utils/           # logger, metrics, errors
+│   ├── integrity_validators.py
+│   ├── integrity_stats.py
+│   └── main.py          # train_and_save, run_inference
+└── tests/
+```
 
 ---
 
-## Contributing  
-See [CONTRIBUTING.md](CONTRIBUTING.md).  
+## Contributing
 
----
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## License  
-Apache-2.0 License – see [LICENSE](LICENSE).  
+## License
+
+Apache-2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ which separates <em>drift</em>, a number sliding out of its declared range, from
 
 A policy network fails quietly. It returns a number of the right type, in the right shape, at the right time, and that number is wrong. Nothing raises. A type checker sees a `float`. The training loop keeps going and the loss curve still looks reasonable.
 
+Reinforcement learning makes this worse than usual, because the two obvious signals both lie. Reward is delayed, so a policy can be wrong for a hundred steps before the return reflects it. And a bounded action space means an invalid decision often gets clamped into a valid one on its way to the actuator, which is exactly the case where a real drone flies and a real log stays empty.
+
 So this repo attaches a validator to both sides of the loop and makes every step answer two separate questions:
 
 | | question | example | means |
@@ -43,9 +45,41 @@ So this repo attaches a validator to both sides of the loop and makes every step
 
 The distinction earns its keep because the two need different responses. Drift means a bound is wrong or a distribution is moving, so you widen, retrain, or investigate. Hallucination means the output space itself was violated, so you stop.
 
-`IntegrityStats` tallies both across a run and prints a report at the end of training and of inference, so a run that completed is not automatically a run that was clean.
-
 **This is not a theoretical feature.** Getting CI green on this repo surfaced a bug the validators had been reporting correctly the whole time while nobody was reading them. `observation_space` declared a single scalar upper bound of `grid_size` across all five dimensions, but the fifth dimension counts down from `max_steps`. Under the shipped config that is 200 against a bound of 20, so **every step of every episode raised an observation drift error**. The validator was right. The declared space was wrong.
+
+---
+
+## The integrity layer
+
+Two validators in [`src/integrity_validators.py`](src/integrity_validators.py), one per side of the loop, plus a counter in [`src/integrity_stats.py`](src/integrity_stats.py).
+
+**`IntegrityValidator`**, attached to `DroneEnv`, runs inside `step()` and appends findings to the returned `info` dict under `integrity_errors`:
+
+| check | classified as | note |
+|---|---|---|
+| `observation_space.contains(obs)` | drift | Observation is cast to the space dtype first, to avoid float32 against float64 false positives |
+| Observation fails to cast at all | drift | Reported as a malformed observation rather than an out-of-range one |
+| `action_space.contains(int(action))` | hallucination | |
+| `np.isfinite(reward)` | drift | Catches `NaN` and `inf` rewards |
+
+**`PolicyIntegrityValidator`**, attached to `PPOAgent`, runs on every `select_action` and `predict`:
+
+| check | classified as | tolerance |
+|---|---|---|
+| Any action probability below zero | drift | strict |
+| Probabilities sum to 1 | drift | `atol` of `1e-2`, tightening to `1e-5` when constructed with `strict=True` |
+| Value estimate is finite | drift | catches a diverged critic |
+| Chosen action index is inside the action space | hallucination | |
+
+**`IntegrityStats`** tallies both streams and prints a rate rather than a raw count, because a count is meaningless without a denominator:
+
+```
+[Training Integrity Report] Steps=2000
+  - Drift errors: 0 (0.00% of steps)
+  - Hallucination errors: 0 (0.00% of steps)
+```
+
+The validators report and continue; they do not halt a run. That is a deliberate choice for a training loop and the wrong one for a flight controller, which is what the Safety Controller in the roadmap is for.
 
 ---
 
@@ -124,18 +158,92 @@ A grid world, deliberately small, so the validator layer is the thing under test
 
 Bounds are per-dimension, for the reason described above. One scalar bound cannot describe both a coordinate and a step counter.
 
-**Action**, `Discrete(5)`: `0` hover, `1` up, `2` down, `3` left, `4` right. Moves clamp at the grid edge, so an illegal move is absorbed rather than rejected.
+**Action**, `Discrete(5)`:
 
-**Reward**: `+10.0` on reaching the goal, `-1.0` per step otherwise. `terminated` on goal, `truncated` at `max_steps`.
+| index | action | effect |
+|---|---|---|
+| `0` | hover | position unchanged |
+| `1` | up | `y + 1`, clamped at `grid_size - 1` |
+| `2` | down | `y - 1`, clamped at `0` |
+| `3` | left | `x - 1`, clamped at `0` |
+| `4` | right | `x + 1`, clamped at `grid_size - 1` |
 
-**Config** ([`configs/env.yaml`](configs/env.yaml)):
+Moves clamp at the grid edge, so an illegal move is absorbed rather than rejected. `action_map` carries the human-readable names.
+
+**Reward**: `+10.0` on reaching the goal, `-1.0` per step otherwise. `terminated` on goal, `truncated` at `max_steps`. The agent starts at the origin and the goal sits at the far corner, so the shortest path under this config is 38 moves.
+
+---
+
+## The PPO agent
+
+An actor-critic with a shared trunk, in [`src/agents/ppo_agent.py`](src/agents/ppo_agent.py). Small on purpose: the point of the repo is the validation layer around it.
+
+```
+observation (5)
+      |
+   Linear(5, 64) + ReLU          shared trunk
+      |
+      +---- Linear(64, 5) + Softmax    policy head, action distribution
+      |
+      +---- Linear(64, 1)              value head, state baseline
+```
+
+The update is standard clipped-surrogate PPO:
+
+| term | value | role |
+|---|---|---|
+| Policy loss | `-min(r * A, clip(r, 1 - eps, 1 + eps) * A)` | the clip stops a single batch from moving the policy too far |
+| Value loss | `0.5 * MSE(return, value)` | trains the baseline |
+| Entropy bonus | `-0.01 * entropy` | keeps the distribution from collapsing early |
+
+Returns are discounted, then normalized. Advantages are normalized again after subtracting the baseline. Both use an `1e-8` epsilon in the denominator.
+
+**Hyperparameters** are currently Python defaults on `PPOAgent.__init__`, not configuration. See Known gaps.
+
+| parameter | value |
+|---|---|
+| `lr` | `3e-4`, Adam |
+| `gamma` | `0.99` |
+| `eps_clip` | `0.2` |
+| `epochs` | `3` update passes per episode |
+
+`select_action` samples from the distribution for exploration during training. `predict` takes the argmax for inference. Both run the policy validator before returning.
+
+---
+
+## Configuration
+
+Only one config file is actually read by the code today.
+
+| file | read by | status |
+|---|---|---|
+| [`configs/env.yaml`](configs/env.yaml) | `DroneEnv._load_config` | **Live** |
+| [`configs/train.yaml`](configs/train.yaml) | nothing | **Dead**. Referenced only by the broken `scripts/train.sh` |
+| [`configs/env-prod.yaml`](configs/env-prod.yaml) | nothing | **Dead** |
+| `.env` (see [`.env.example`](.env.example)) | `scripts/run_server.sh` only | Shell-level. No Python module reads an environment variable |
 
 ```yaml
+# configs/env.yaml, the one that is loaded
 grid_size: 20
-num_drones: 10
-obstacle_density: 0.1
+num_drones: 10          # read into an attribute, never used
+obstacle_density: 0.1   # read into an attribute, never used
 max_steps: 200
 ```
+
+`DroneEnv` resolves a relative config path against the repository root, so it works the same from the repo root, from `src/`, and inside the container. If PyYAML is missing it falls back to a minimal line parser rather than failing.
+
+---
+
+## Request lifecycle
+
+What happens on a call to the service, from [`src/api/app.py`](src/api/app.py):
+
+1. `add_metrics` middleware stamps a start time.
+2. The route runs. `/predict` hands the payload to `PPOAgent.predict`; failures are wrapped as `APIError` and rendered as `{"error": "..."}` with status 500.
+3. The middleware records `REQUEST_COUNT` and `REQUEST_LATENCY`, both labelled by method and endpoint, then logs a line like `POST /predict completed in 0.032s`.
+4. Prometheus scrapes `GET /metrics`; the orchestrator polls `GET /healthz`.
+
+Weights load once at startup from `models/ppo_drone.pt`. If that file is absent the service logs a warning and serves an untrained policy rather than refusing to start, which is the right call for a probe endpoint and the wrong one for a prediction endpoint.
 
 ---
 
@@ -151,6 +259,7 @@ Worth reading before the deployment sections. The repository name is older than 
 | FastAPI service, `/metrics` and `/healthz` | **Implemented** |
 | Docker image, Compose, Kubernetes manifests, Prometheus and Grafana config | **Implemented** as configuration |
 | `/predict` end to end | **Broken**, see Known gaps |
+| Hyperparameters from `configs/train.yaml` | **Not wired**, defaults live in Python |
 | Multi-agent, more than one drone | **Not implemented**. `num_drones` is read into an attribute and never used; the env tracks a single position vector |
 | MAPF, multi-agent path finding | **Not implemented**. No conflict resolution, no reservation table, no joint planner |
 | Obstacles | **Not implemented**. `obstacle_density` is read and never used |
@@ -167,7 +276,22 @@ The multi-agent and MAPF pieces are the roadmap the name points at, not a descri
 {"state": {"x": 1, "y": 2}}  ->  500  "Prediction failed: must be real number, not dict"
 ```
 
-`tests/test_api.py` does not catch this, because it replaces `PPOAgent` with a stub that returns a constant. The fix is to agree on one contract, most naturally the 5-number observation vector, then make the schema and the agent match.
+`tests/test_api.py` does not catch this, because it replaces `PPOAgent` with a stub that returns a constant. The fix is to agree on one contract, most naturally the 5-number observation vector, then make the schema and the agent match. Note that `predict` returns an integer index, while `src/request_response_flow.MD` documents a response of `{"action": "move_up"}`; the same fix should decide whether the API speaks indices or names.
+
+**`scripts/train.sh` does not run.** It invokes `python src/main.py --config configs/train.yaml`, but `main.py` has no argument parsing and the `src/` layout needs the editable install. Use `python -m main`.
+
+**`tests/conftest.py` swallows import errors.** It catches any failure importing the real `DroneEnv` and substitutes a stub. That is why a missing dependency once surfaced as `AttributeError: 'DroneEnv' object has no attribute 'reset'` rather than an import error, and why coverage sat at 38 percent while appearing to exercise the environment.
+
+### Roadmap
+
+Roughly in dependency order:
+
+1. Fix the `/predict` contract, and cover it with a test that does not stub the agent.
+2. Wire `configs/train.yaml` into `PPOAgent` so hyperparameters stop being Python defaults.
+3. Obstacles, using the `obstacle_density` field that already exists in config.
+4. Multiple drones: a per-drone observation and action, and a reward that prices collisions.
+5. MAPF proper: conflict detection between planned paths, then a resolution strategy.
+6. Safety Controller, the first component allowed to veto rather than only report.
 
 ---
 
@@ -207,7 +331,7 @@ Total reward over 5 steps = -5.00
   - Hallucination errors: 0 (0.00% of steps)
 ```
 
-Those two zeroes are the whole point of the section above. Before the observation-space bounds were fixed, that same run reported a drift error on all 2000 of 2000 steps. Ten episodes on a 20x20 grid is far too short to reach the goal, which is why every episode returns the `-200.00` floor; the run demonstrates the validator layer, not convergence.
+Those two zeroes are the whole point of the section above. Before the observation-space bounds were fixed, that same run reported a drift error on all 2000 of 2000 steps. Ten episodes on a 20x20 grid is far too short to reach a goal 38 moves away, which is why every episode returns the `-200.00` floor; the run demonstrates the validator layer, not convergence.
 
 Serve the API:
 
@@ -232,9 +356,7 @@ curl http://localhost:8000/healthz
 | `GET` | `/metrics` | Prometheus exposition format | Working |
 | `GET` | `/healthz` | Liveness and readiness probe | Working |
 
-Weights load at startup from `models/ppo_drone.pt`. If that file is absent the service logs a warning and serves an untrained policy rather than refusing to start, which is the right call for a probe endpoint and the wrong one for a prediction endpoint.
-
-Every request passes through middleware recording `REQUEST_COUNT` and `REQUEST_LATENCY` by method and endpoint. Notes in [`docs/API.md`](docs/API.md).
+Notes in [`docs/API.md`](docs/API.md).
 
 ---
 
@@ -255,7 +377,19 @@ pytest --cov=src --cov-report=term-missing
 
 Current state on `main`: 6 passing, 85 percent line coverage.
 
-**One caveat worth knowing.** `tests/conftest.py` catches any import failure of the real `DroneEnv` and substitutes a stub. That is why a missing dependency once surfaced as `AttributeError: 'DroneEnv' object has no attribute 'reset'` instead of an import error, and why coverage sat at 38 percent while appearing to exercise the environment. The stub is still in place.
+---
+
+## Continuous integration
+
+Three workflows, all on push and pull request against `main`.
+
+| workflow | what it does |
+|---|---|
+| [`test.yml`](.github/workflows/test.yml) | Python 3.10, installs requirements and the package editable, runs `pytest -v` |
+| [`docker.yml`](.github/workflows/docker.yml) | Builds `docker/Dockerfile`, then runs the suite inside the image |
+| [`codeql-analysis.yml`](.github/workflows/codeql-analysis.yml) | CodeQL static analysis for Python |
+
+`_ci-cd.yml` is a manual `workflow_dispatch` duplicate of `test.yml`. The Docker job matters because it catches packaging problems the plain test job cannot: it is the job that proves the image can import the `src/` layout at all.
 
 ---
 
@@ -288,6 +422,14 @@ kubectl apply -f docker/k8s/
 
 Panels cover request latency p95, requests by endpoint, training reward distribution and error rate.
 
+[`src/utils/metrics.py`](src/utils/metrics.py) declares three collectors, but only two are ever written:
+
+| collector | emitted |
+|---|---|
+| `api_requests_total` | Yes, by the middleware on every request |
+| `api_request_latency_seconds` | Yes, by the middleware on every request |
+| `training_reward` | **No.** Declared and never observed, so the training reward panel has no series behind it. The training loop prints episode reward to stdout instead |
+
 ---
 
 ## Repository layout
@@ -295,7 +437,7 @@ Panels cover request latency p95, requests by endpoint, training reward distribu
 ```
 multi-agent-rl-mapf-drone-navigation/
 ├── architecture/        # Design diagrams, low level specs, interview summary
-├── configs/             # env.yaml, env-prod.yaml, train.yaml
+├── configs/             # env.yaml (live), train.yaml and env-prod.yaml (not yet wired)
 ├── docker/              # Dockerfile, Dockerfile.prod, compose, k8s manifests
 ├── docs/                # API, ARCHITECTURE, DEPLOYMENT
 ├── monitoring/          # Prometheus, Grafana, Alertmanager

--- a/README.md
+++ b/README.md
@@ -283,6 +283,48 @@ Worth reading before the deployment sections. The repository name is older than 
 
 The multi-agent and MAPF pieces are the roadmap the name points at, not a description of `src/`.
 
+### The designed system
+
+The repository carries a full low level design that `src/` has never implemented. It is worth reading as intent, and worth being explicit that it is intent: the actor pipeline, the bounded queues, the safety arbiter and the server side re-weighting loop are all design, not code.
+
+<p align="center">
+  <img src="assets/low-level-design.svg" alt="Low level design: an on-drone actor pipeline from ingestion through preprocess and policy into a safety controller, with bounded queues between stages, gRPC and REST interfaces, and a server side of ingest gateway, stream processor, analytics, weight learner and config API, under a 25 millisecond tick budget." width="100%">
+</p>
+
+<details>
+<summary>Same diagram as text</summary>
+
+```text
+  ON DRONE                                            budget: 25 ms per tick
+    Root Supervisor        restarts, deadlines, time sync    beacon 200 ms
+         |
+    Ingestion actors       IMU, GPS, LiDAR, camera           Q1  64    5 ms
+         |                 Frame{seq, ts, payload}
+    Preprocess pipeline    calibrate, filter, fuse           Q2  64    8 ms
+         |                 Features[list[float]]
+    Policy service         candidates + alignment scorer     Q3 128    7 ms
+         |                 weighted by the constitution
+    Safety Controller      geofence, separation, altitude,             5 ms
+         |                 return to home. Final arbiter.
+    Black Box              ring buffer, last N minutes
+
+  INTERFACES
+    gRPC, data plane       AppendEvents / HealthBeat / Decide
+                           mTLS, deadlines 50 to 100 ms
+    REST, control plane    GET /v1/constitution, POST /v1/override,
+                           GET /v1/flags. Signed, ETag cached.
+
+  SERVER
+    Ingest Gateway  ->  Stream Processor  ->  Event Store + time series
+                                          ->  Analytics and Evals
+                                          ->  Weight Learner
+                                          ->  Config and Weights API
+```
+
+</details>
+
+Full written spec in [`architecture/low_level_design.txt`](architecture/low_level_design.txt).
+
 ### Known gaps
 
 **`/predict` currently rejects every input.** The request schema declares `state: dict`, while `PPOAgent.predict` calls `torch.tensor(state)` and needs a numeric sequence. No body satisfies both:

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 <a href="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/docker.yml"><img src="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/docker.yml/badge.svg?branch=main" alt="Docker Build"/></a>
 <a href="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/codeql-analysis.yml"><img src="https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/actions/workflows/codeql-analysis.yml/badge.svg?branch=main" alt="CodeQL"/></a>
 
-<img alt="python 3.10" src="https://img.shields.io/badge/python-3.10-0ea5e9?style=flat-square&labelColor=0f172a">
-<img alt="PPO in PyTorch 2.2.2" src="https://img.shields.io/badge/PPO-PyTorch_2.2.2-164e63?style=flat-square&labelColor=0f172a">
-<img alt="env gymnasium" src="https://img.shields.io/badge/env-gymnasium-164e63?style=flat-square&labelColor=0f172a">
-<img alt="tests 6 passing" src="https://img.shields.io/badge/tests-6_passing-164e63?style=flat-square&labelColor=0f172a">
-<img alt="coverage 85 percent" src="https://img.shields.io/badge/coverage-85%25-164e63?style=flat-square&labelColor=0f172a">
-<img alt="license Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-164e63?style=flat-square&labelColor=0f172a">
+<img alt="python 3.10" src="https://img.shields.io/badge/python-3.10-d7dee7?style=flat-square&labelColor=12161d">
+<img alt="PPO in PyTorch 2.2.2" src="https://img.shields.io/badge/PPO-PyTorch_2.2.2-8a95a5?style=flat-square&labelColor=12161d">
+<img alt="env gymnasium" src="https://img.shields.io/badge/env-gymnasium-8a95a5?style=flat-square&labelColor=12161d">
+<img alt="tests 6 passing" src="https://img.shields.io/badge/tests-6_passing-8a95a5?style=flat-square&labelColor=12161d">
+<img alt="coverage 85 percent" src="https://img.shields.io/badge/coverage-85%25-8a95a5?style=flat-square&labelColor=12161d">
+<img alt="license Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-8a95a5?style=flat-square&labelColor=12161d">
 
 <br/><br/>
 
@@ -88,33 +88,39 @@ The validators report and continue; they do not halt a run. That is a deliberate
 The control loop is small. The validators hang off both halves of it, and everything they find funnels into one counter.
 
 <p align="center">
-  <img src="assets/architecture.svg" alt="PPO control loop: configs/env.yaml feeds DroneEnv, which exchanges observations and actions with PPOAgent. An IntegrityValidator sits inside the environment and a PolicyIntegrityValidator inside the agent; both report into IntegrityStats. The agent is served behind FastAPI, scraped by Prometheus and Grafana." width="100%">
+  <img src="assets/architecture.svg" alt="Architecture: configs/env.yaml feeds DroneEnv; the PPO agent closes the loop; a validator band watches both sides and reports into IntegrityStats; the policy is served behind FastAPI and scraped by Prometheus." width="100%">
 </p>
-
-The three pink boxes are the subject of this repository. Everything else is scaffolding around them.
 
 <details>
-<summary><b>Original design diagrams</b> (wide panoramas, click through for full size)</summary>
-<br/>
+<summary>Same diagram as text</summary>
 
-These are the hand-drawn system designs from the original build. They are very wide, so they read poorly inline; open each one full size.
-
-<p align="center">
-  <a href="architecture/drone_high_lv_system_design.png"><img src="architecture/drone_high_lv_system_design.png" alt="High level system design" width="100%"></a>
-  <br/><em>High level design.</em> <a href="architecture/drone_high_lv_system_design.png">Open full size</a>
-  <br/><br/>
-  <a href="architecture/drone_low_lv_system_design.png"><img src="architecture/drone_low_lv_system_design.png" alt="Low level system design" width="100%"></a>
-  <br/><em>Low level design.</em> <a href="architecture/drone_low_lv_system_design.png">Open full size</a>
-</p>
-
-<p align="center">
-  <img src="architecture/drones_matrix_RL.png" alt="Reward pattern reference" width="88%">
-  <br/><em>Reward pattern reference: event-based against continuous shaping, on both the self and interaction axes.</em>
-</p>
-
-Written specs live in [`architecture/low_level_design.txt`](architecture/low_level_design.txt) and [`architecture/summary.md`](architecture/summary.md).
+```text
+  CONFIG       configs/env.yaml            grid_size 20, max_steps 200
+                    |
+  ENVIRONMENT  DroneEnv (gymnasium)
+                    |  reset() / step(action)  ->  obs, reward, terminated, truncated, info
+                    |  observation   Box(5)        x, y, goal_x, goal_y, steps_remaining
+                    |  action        Discrete(5)   hover, up, down, left, right (clamped)
+                    v
+  AGENT        PPOAgent (PyTorch)
+                    |  PPOPolicy     shared Linear(5,64)+ReLU  ->  policy head (5), value head (1)
+                    |  update        clipped surrogate, eps_clip 0.2, gamma 0.99, Adam 3e-4
+                    |  act           sample while training, argmax at inference
+                    v
+  VALIDATORS   the subject of this repository
+                    |  IntegrityValidator         obs in space? action legal? reward finite?
+                    |  PolicyIntegrityValidator   probs sum to 1? value finite? action in space?
+                    |  IntegrityStats             drift vs hallucination, as a rate per step
+                    v
+  SERVING      FastAPI  /predict /metrics /healthz  ->  Prometheus + Grafana
+               weights load once from models/ppo_drone.pt
+```
 
 </details>
+
+The bright band is the subject of this repository. Everything else is scaffolding around it.
+
+The original hand-drawn design panoramas are kept in [`architecture/`](architecture/) for provenance. They are not shown here because they were drawn far too wide to read at README scale; the diagrams above are reconstructions of the same material.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/hero.svg" alt="Drone navigation that checks its own work: a PPO agent on a grid world wrapped in a validator layer separating drift from hallucination" width="100%">
+</p>
+
 <div align="center">
 
 <b><font size="6">Multi-Agent RL MAPF Drone Navigation</font></b>

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,113 +1,146 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 1200" width="980" height="1200" role="img" aria-label="Architecture: configs/env.yaml feeds the DroneEnv, the PPO agent closes the loop, a validator band watches both sides and reports into IntegrityStats, and the policy is served behind FastAPI" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 1240" width="980" height="1240" role="img" aria-label="System map: configs/env.yaml feeds the DroneEnv, the PPO agent closes the loop, a validator band watches both sides and reports into IntegrityStats, and the policy is served behind FastAPI" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
-  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#12161d"/>
-    <stop offset="1" stop-color="#0a0d12"/>
+  <linearGradient id="bg" x1="0" y1="0" x2="0.4" y2="1">
+    <stop offset="0" stop-color="#0d131b"/>
+    <stop offset="0.55" stop-color="#080c12"/>
+    <stop offset="1" stop-color="#05080c"/>
   </linearGradient>
+  <pattern id="grid" width="26" height="26" patternUnits="userSpaceOnUse">
+    <circle cx="1" cy="1" r="0.7" fill="#16202c"/>
+  </pattern>
   <linearGradient id="chrome" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#8d99a8"/>
-    <stop offset="0.35" stop-color="#e6edf5"/>
-    <stop offset="0.62" stop-color="#9aa6b5"/>
-    <stop offset="1" stop-color="#dfe7f0"/>
+    <stop offset="0" stop-color="#5d6b7d"/>
+    <stop offset="0.28" stop-color="#eaf2fa"/>
+    <stop offset="0.5" stop-color="#93a2b4"/>
+    <stop offset="0.72" stop-color="#f2f8ff"/>
+    <stop offset="1" stop-color="#66748a"/>
   </linearGradient>
   <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#1e242e"/>
-    <stop offset="1" stop-color="#151a22"/>
+    <stop offset="0" stop-color="#1b2431"/>
+    <stop offset="0.5" stop-color="#151d28"/>
+    <stop offset="1" stop-color="#111820"/>
   </linearGradient>
   <linearGradient id="panelLive" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#28303c"/>
-    <stop offset="1" stop-color="#1b212a"/>
+    <stop offset="0" stop-color="#26323f"/>
+    <stop offset="1" stop-color="#161e28"/>
+  </linearGradient>
+  <linearGradient id="edge" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#3d4d61" stop-opacity="0.2"/>
+    <stop offset="0.5" stop-color="#8fa3ba" stop-opacity="0.75"/>
+    <stop offset="1" stop-color="#3d4d61" stop-opacity="0.2"/>
+  </linearGradient>
+  <linearGradient id="spine" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#7fd4ff" stop-opacity="0"/>
+    <stop offset="0.12" stop-color="#7fd4ff" stop-opacity="0.55"/>
+    <stop offset="0.88" stop-color="#7fd4ff" stop-opacity="0.55"/>
+    <stop offset="1" stop-color="#7fd4ff" stop-opacity="0"/>
   </linearGradient>
   <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
-    <path d="M0,0 L10,5 L0,10 z" fill="#aab6c6"/>
+    <path d="M0,0 L10,5 L0,10 z" fill="#8fa3ba"/>
   </marker>
   <marker id="ab" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
-    <path d="M0,0 L10,5 L0,10 z" fill="#e6edf5"/>
+    <path d="M0,0 L10,5 L0,10 z" fill="#eaf2fa"/>
   </marker>
 </defs>
 
-<rect x="0" y="0" width="980" height="1200" rx="12" fill="url(#bg)"/>
+<rect x="0" y="0" width="980" height="1240" rx="14" fill="url(#bg)"/>
+<rect x="0" y="0" width="980" height="1240" rx="14" fill="url(#grid)"/>
 
-<text x="34" y="58" fill="#f2f6fa" font-size="32" font-weight="700">Architecture</text>
-<text x="34" y="90" fill="#93a1b3" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
-<text x="946" y="58" fill="#8f9dae" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
-<text x="946" y="86" fill="#8f9dae" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
+<rect x="34" y="150" width="2" height="1010" fill="url(#spine)"/>
 
-<line x1="34" y1="116" x2="946" y2="116" stroke="#2b333f" stroke-width="1"/>
+<text x="34" y="46" fill="#7fd4ff" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SYSTEM MAP</text>
+<text x="34" y="88" fill="#f4f8fc" font-size="34" font-weight="700" letter-spacing="0.4">Architecture</text>
+<text x="34" y="118" fill="#8ea0b5" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
+<rect x="700" y="30" width="2" height="62" fill="#2b3949"/>
+<text x="946" y="52" fill="#93a6bb" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
+<text x="946" y="78" fill="#93a6bb" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
 
-<text x="34" y="154" fill="#7e8b9c" font-size="17" font-weight="700" letter-spacing="1.8">CONFIG</text>
-<text x="170" y="154" fill="#6f7c8d" font-size="18">the only file the code actually reads</text>
-<rect x="34" y="172" width="440" height="88" rx="9" fill="url(#panel)" stroke="#46515f" stroke-width="1.8"/>
-<text x="56" y="208" fill="#e9eff6" font-size="22" font-weight="700">configs/env.yaml</text>
-<text x="56" y="240" fill="#9dabbc" font-size="19">grid_size 20, max_steps 200</text>
+<text x="62" y="170" fill="#7fd4ff" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
+<text x="96" y="170" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">CONFIG</text>
+<text x="216" y="170" fill="#6d7d90" font-size="18">the only file the code actually reads</text>
+<line x1="62" y1="184" x2="946" y2="184" stroke="#1e2a37" stroke-width="1"/>
 
-<line x1="34" y1="292" x2="946" y2="292" stroke="#2b333f" stroke-width="1"/>
+<rect x="62" y="200" width="440" height="88" rx="6" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="74" y="200.7" width="416" height="1.4" fill="url(#edge)"/>
+<text x="84" y="236" fill="#eef4fa" font-size="22" font-weight="700">configs/env.yaml</text>
+<text x="84" y="268" fill="#9fb0c3" font-size="19" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid_size 20, max_steps 200</text>
 
-<text x="34" y="330" fill="#7e8b9c" font-size="17" font-weight="700" letter-spacing="1.8">ENVIRONMENT</text>
-<text x="220" y="330" fill="#6f7c8d" font-size="18">DroneEnv, a gymnasium grid world</text>
+<text x="62" y="342" fill="#7fd4ff" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">02</text>
+<text x="96" y="342" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">ENVIRONMENT</text>
+<text x="280" y="342" fill="#6d7d90" font-size="18">DroneEnv, a gymnasium grid world</text>
+<line x1="62" y1="356" x2="946" y2="356" stroke="#1e2a37" stroke-width="1"/>
 
-<rect x="34" y="348" width="440" height="152" rx="9" fill="url(#panel)" stroke="#46515f" stroke-width="1.8"/>
-<text x="56" y="384" fill="#e9eff6" font-size="22" font-weight="700">reset() and step(action)</text>
-<text x="56" y="418" fill="#9dabbc" font-size="19">returns obs, reward, terminated,</text>
-<text x="56" y="446" fill="#9dabbc" font-size="19">truncated, info</text>
-<text x="56" y="480" fill="#8f9dae" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+10 at goal, -1 per step</text>
+<rect x="62" y="372" width="420" height="152" rx="6" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="74" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
+<text x="84" y="408" fill="#eef4fa" font-size="22" font-weight="700">reset() and step(action)</text>
+<text x="84" y="442" fill="#9fb0c3" font-size="19">returns obs, reward, terminated,</text>
+<text x="84" y="470" fill="#9fb0c3" font-size="19">truncated, info</text>
+<text x="84" y="504" fill="#7f92a8" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+10 at goal, -1 per step</text>
 
-<rect x="506" y="348" width="440" height="152" rx="9" fill="url(#panel)" stroke="#46515f" stroke-width="1.8"/>
-<text x="528" y="384" fill="#e9eff6" font-size="22" font-weight="700">spaces</text>
-<text x="528" y="418" fill="#9dabbc" font-size="19">observation Box(5): x, y, goal x,</text>
-<text x="528" y="446" fill="#9dabbc" font-size="19">goal y, steps remaining</text>
-<text x="528" y="480" fill="#9dabbc" font-size="19">action Discrete(5), edge clamped</text>
+<rect x="526" y="372" width="420" height="152" rx="6" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="538" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
+<text x="548" y="408" fill="#eef4fa" font-size="22" font-weight="700">spaces</text>
+<text x="548" y="442" fill="#9fb0c3" font-size="19">observation Box(5): x, y, goal x,</text>
+<text x="548" y="470" fill="#9fb0c3" font-size="19">goal y, steps remaining</text>
+<text x="548" y="504" fill="#9fb0c3" font-size="19">action Discrete(5), edge clamped</text>
 
-<path d="M 474 424 L 500 424" stroke="#aab6c6" stroke-width="2" fill="none" marker-end="url(#a)"/>
+<path d="M 482 448 L 518 448" stroke="#8fa3ba" stroke-width="2" fill="none" marker-end="url(#a)"/>
 
-<line x1="34" y1="532" x2="946" y2="532" stroke="#2b333f" stroke-width="1"/>
+<text x="62" y="578" fill="#7fd4ff" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">03</text>
+<text x="96" y="578" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">AGENT</text>
+<text x="200" y="578" fill="#6d7d90" font-size="18">PPOAgent, actor and critic on one trunk</text>
+<line x1="62" y1="592" x2="946" y2="592" stroke="#1e2a37" stroke-width="1"/>
 
-<text x="34" y="570" fill="#7e8b9c" font-size="17" font-weight="700" letter-spacing="1.8">AGENT</text>
-<text x="150" y="570" fill="#6f7c8d" font-size="18">PPOAgent, actor and critic on one trunk</text>
+<rect x="62" y="608" width="420" height="152" rx="6" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="74" y="608.7" width="396" height="1.4" fill="url(#edge)"/>
+<text x="84" y="644" fill="#eef4fa" font-size="22" font-weight="700">PPOPolicy</text>
+<text x="84" y="678" fill="#9fb0c3" font-size="19">shared Linear(5, 64) + ReLU</text>
+<text x="84" y="706" fill="#9fb0c3" font-size="19">policy head (5), value head (1)</text>
+<text x="84" y="740" fill="#7f92a8" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">sample training, argmax serving</text>
 
-<rect x="34" y="588" width="440" height="152" rx="9" fill="url(#panel)" stroke="#46515f" stroke-width="1.8"/>
-<text x="56" y="624" fill="#e9eff6" font-size="22" font-weight="700">PPOPolicy</text>
-<text x="56" y="658" fill="#9dabbc" font-size="19">shared Linear(5, 64) + ReLU</text>
-<text x="56" y="686" fill="#9dabbc" font-size="19">policy head (5), value head (1)</text>
-<text x="56" y="720" fill="#8f9dae" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">sample training, argmax serving</text>
+<rect x="526" y="608" width="420" height="152" rx="6" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="538" y="608.7" width="396" height="1.4" fill="url(#edge)"/>
+<text x="548" y="644" fill="#eef4fa" font-size="22" font-weight="700">clipped surrogate update</text>
+<text x="548" y="678" fill="#9fb0c3" font-size="19">policy, value and entropy terms</text>
+<text x="548" y="712" fill="#7f92a8" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">eps_clip 0.2, gamma 0.99</text>
+<text x="548" y="740" fill="#7f92a8" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Adam lr 3e-4, 3 epochs</text>
 
-<rect x="506" y="588" width="440" height="152" rx="9" fill="url(#panel)" stroke="#46515f" stroke-width="1.8"/>
-<text x="528" y="624" fill="#e9eff6" font-size="22" font-weight="700">clipped surrogate update</text>
-<text x="528" y="658" fill="#9dabbc" font-size="19">policy, value and entropy terms</text>
-<text x="528" y="692" fill="#8f9dae" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">eps_clip 0.2, gamma 0.99</text>
-<text x="528" y="720" fill="#8f9dae" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Adam lr 3e-4, 3 epochs</text>
+<path d="M 482 684 L 518 684" stroke="#8fa3ba" stroke-width="2" fill="none" marker-end="url(#a)"/>
 
-<path d="M 474 664 L 500 664" stroke="#aab6c6" stroke-width="2" fill="none" marker-end="url(#a)"/>
+<text x="62" y="814" fill="#eaf2fa" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">04</text>
+<text x="96" y="814" fill="#ffffff" font-size="17" font-weight="700" letter-spacing="2.2">VALIDATORS</text>
+<text x="262" y="814" fill="#a9bbcd" font-size="18">every step answers both questions; the subject of this repository</text>
+<line x1="62" y1="828" x2="946" y2="828" stroke="#42566b" stroke-width="1"/>
 
-<line x1="34" y1="772" x2="946" y2="772" stroke="#2b333f" stroke-width="1"/>
+<rect x="62" y="844" width="420" height="146" rx="6" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
+<path d="M 74 858 L 74 846 L 86 846" stroke="#7fd4ff" stroke-width="2" fill="none"/>
+<path d="M 470 976 L 470 988 L 458 988" stroke="#7fd4ff" stroke-width="2" fill="none"/>
+<text x="84" y="882" fill="#ffffff" font-size="22" font-weight="700">IntegrityValidator</text>
+<text x="84" y="916" fill="#ccd9e7" font-size="19">observation inside its space?</text>
+<text x="84" y="944" fill="#ccd9e7" font-size="19">action legal? reward finite?</text>
+<text x="84" y="972" fill="#8ba0b6" font-size="17">on the environment side</text>
 
-<text x="34" y="810" fill="#e6edf5" font-size="17" font-weight="700" letter-spacing="1.8">VALIDATORS</text>
-<text x="200" y="810" fill="#aab6c6" font-size="18">every step answers both questions; the subject of this repository</text>
+<rect x="526" y="844" width="420" height="146" rx="6" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
+<path d="M 538 858 L 538 846 L 550 846" stroke="#7fd4ff" stroke-width="2" fill="none"/>
+<path d="M 934 976 L 934 988 L 922 988" stroke="#7fd4ff" stroke-width="2" fill="none"/>
+<text x="548" y="882" fill="#ffffff" font-size="22" font-weight="700">PolicyIntegrityValidator</text>
+<text x="548" y="916" fill="#ccd9e7" font-size="19">probabilities sum to 1?</text>
+<text x="548" y="944" fill="#ccd9e7" font-size="19">value finite? action in space?</text>
+<text x="548" y="972" fill="#8ba0b6" font-size="17">on the agent side</text>
 
-<rect x="34" y="828" width="440" height="140" rx="9" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.6"/>
-<text x="56" y="864" fill="#ffffff" font-size="22" font-weight="700">IntegrityValidator</text>
-<text x="56" y="898" fill="#c3cedd" font-size="19">observation inside its space?</text>
-<text x="56" y="926" fill="#c3cedd" font-size="19">action legal? reward finite?</text>
-<text x="56" y="952" fill="#8f9dae" font-size="17">on the environment side</text>
+<path d="M 482 910 L 518 910" stroke="#eaf2fa" stroke-width="2.2" fill="none" marker-end="url(#ab)"/>
 
-<rect x="506" y="828" width="440" height="140" rx="9" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.6"/>
-<text x="528" y="864" fill="#ffffff" font-size="22" font-weight="700">PolicyIntegrityValidator</text>
-<text x="528" y="898" fill="#c3cedd" font-size="19">probabilities sum to 1?</text>
-<text x="528" y="926" fill="#c3cedd" font-size="19">value finite? action in space?</text>
-<text x="528" y="952" fill="#8f9dae" font-size="17">on the agent side</text>
+<rect x="62" y="1010" width="884" height="86" rx="6" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
+<text x="84" y="1046" fill="#ffffff" font-size="22" font-weight="700">IntegrityStats</text>
+<text x="84" y="1078" fill="#ccd9e7" font-size="19">drift against hallucination, reported as a rate per step, never as a bare count</text>
 
-<path d="M 474 890 L 500 890" stroke="#e6edf5" stroke-width="2.2" fill="none" marker-end="url(#ab)"/>
+<text x="62" y="1150" fill="#7fd4ff" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">05</text>
+<text x="96" y="1150" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">SERVING</text>
+<text x="222" y="1150" fill="#6d7d90" font-size="18">validators report, but never halt a run</text>
+<line x1="62" y1="1164" x2="946" y2="1164" stroke="#1e2a37" stroke-width="1"/>
 
-<rect x="34" y="988" width="912" height="88" rx="9" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.6"/>
-<text x="56" y="1024" fill="#ffffff" font-size="22" font-weight="700">IntegrityStats</text>
-<text x="56" y="1056" fill="#c3cedd" font-size="19">drift against hallucination, reported as a rate per step, never as a bare count</text>
-
-<line x1="34" y1="1108" x2="946" y2="1108" stroke="#2b333f" stroke-width="1"/>
-
-<text x="34" y="1146" fill="#7e8b9c" font-size="17" font-weight="700" letter-spacing="1.8">SERVING</text>
-<text x="168" y="1146" fill="#6f7c8d" font-size="18">validators report, but never halt a run</text>
-<rect x="34" y="1160" width="440" height="26" rx="6" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="56" y="1179" fill="#9dabbc" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FastAPI /predict /metrics /healthz</text>
-<rect x="506" y="1160" width="440" height="26" rx="6" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="528" y="1179" fill="#9dabbc" font-size="17">Prometheus and Grafana scrape /metrics</text>
+<rect x="62" y="1180" width="420" height="34" rx="5" fill="url(#panel)" stroke="#3a4859" stroke-width="1.4"/>
+<text x="84" y="1203" fill="#9fb0c3" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FastAPI /predict /metrics /healthz</text>
+<rect x="526" y="1180" width="420" height="34" rx="5" fill="url(#panel)" stroke="#3a4859" stroke-width="1.4"/>
+<text x="548" y="1203" fill="#9fb0c3" font-size="18">Prometheus and Grafana scrape /metrics</text>
 </svg>

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 520" width="1200" height="520" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="ar-cyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#00d4ff"/>
+    </marker>
+    <marker id="ar-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b537f2"/>
+    </marker>
+    <marker id="ar-pink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#ff006e"/>
+    </marker>
+    <marker id="ar-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#39ff14"/>
+    </marker>
+    <marker id="ar-slate" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1200" height="520" rx="14" fill="#0a1422"/>
+
+  <text x="30" y="38" fill="#e2e8f0" font-size="19" font-weight="700">PPO control loop</text>
+  <text x="215" y="38" fill="#94a3b8" font-size="15">the validator layer is in pink; everything else is scaffolding around it</text>
+
+  <rect x="20" y="130" width="190" height="76" rx="9" fill="#0d1b2a" stroke="#38bdf8" stroke-width="2"/>
+  <text x="115" y="162" fill="#e2e8f0" font-size="14.5" font-weight="700" text-anchor="middle">configs/env.yaml</text>
+  <text x="115" y="184" fill="#94a3b8" font-size="12.5" text-anchor="middle">grid 20x20, 200 max steps</text>
+
+  <rect x="250" y="62" width="360" height="252" rx="12" fill="#0d1f30" stroke="#00d4ff" stroke-width="2"/>
+  <text x="270" y="88" fill="#7dd3fc" font-size="15.5" font-weight="700">DroneEnv (gymnasium)</text>
+
+  <rect x="270" y="102" width="320" height="86" rx="8" fill="#132a3f" stroke="#00d4ff" stroke-width="1.6"/>
+  <text x="430" y="127" fill="#e2e8f0" font-size="14" font-weight="700" text-anchor="middle">reset() and step(action)</text>
+  <text x="430" y="149" fill="#94a3b8" font-size="12.5" text-anchor="middle">obs, reward, terminated,</text>
+  <text x="430" y="168" fill="#94a3b8" font-size="12.5" text-anchor="middle">truncated, info</text>
+
+  <rect x="270" y="206" width="320" height="90" rx="8" fill="#2a1220" stroke="#ff006e" stroke-width="2.4"/>
+  <text x="430" y="231" fill="#ffd7e6" font-size="14" font-weight="700" text-anchor="middle">IntegrityValidator</text>
+  <text x="430" y="253" fill="#f8b4ce" font-size="12.5" text-anchor="middle">observation inside its space?</text>
+  <text x="430" y="272" fill="#f8b4ce" font-size="12.5" text-anchor="middle">action legal? reward finite?</text>
+
+  <rect x="700" y="62" width="470" height="252" rx="12" fill="#181f38" stroke="#b537f2" stroke-width="2"/>
+  <text x="720" y="88" fill="#d8b4fe" font-size="15.5" font-weight="700">PPOAgent (PyTorch)</text>
+
+  <rect x="720" y="102" width="430" height="86" rx="8" fill="#1b263b" stroke="#b537f2" stroke-width="1.6"/>
+  <text x="935" y="127" fill="#e2e8f0" font-size="14" font-weight="700" text-anchor="middle">PPOPolicy</text>
+  <text x="935" y="149" fill="#94a3b8" font-size="12.5" text-anchor="middle">shared Linear(5, 64) + ReLU</text>
+  <text x="935" y="168" fill="#94a3b8" font-size="12.5" text-anchor="middle">policy head (5), value head (1)</text>
+
+  <rect x="720" y="206" width="430" height="90" rx="8" fill="#2a1220" stroke="#ff006e" stroke-width="2.4"/>
+  <text x="935" y="231" fill="#ffd7e6" font-size="14" font-weight="700" text-anchor="middle">PolicyIntegrityValidator</text>
+  <text x="935" y="253" fill="#f8b4ce" font-size="12.5" text-anchor="middle">probabilities sum to 1? value finite?</text>
+  <text x="935" y="272" fill="#f8b4ce" font-size="12.5" text-anchor="middle">chosen action inside the space?</text>
+
+  <path d="M 210 168 L 244 168" stroke="#38bdf8" stroke-width="2.2" fill="none" marker-end="url(#ar-cyan)"/>
+
+  <path d="M 610 126 L 694 126" stroke="#00d4ff" stroke-width="2.4" fill="none" marker-end="url(#ar-cyan)"/>
+  <text x="652" y="116" fill="#7dd3fc" font-size="12.5" font-weight="600" text-anchor="middle">observation</text>
+
+  <path d="M 700 168 L 616 168" stroke="#b537f2" stroke-width="2.4" fill="none" marker-end="url(#ar-purple)"/>
+  <text x="658" y="158" fill="#d8b4fe" font-size="12.5" font-weight="600" text-anchor="middle">action</text>
+
+  <path d="M 430 296 C 430 360, 560 372, 606 400" stroke="#ff006e" stroke-width="2" fill="none" stroke-dasharray="6 5" marker-end="url(#ar-pink)"/>
+  <path d="M 935 296 C 935 360, 830 372, 784 400" stroke="#ff006e" stroke-width="2" fill="none" stroke-dasharray="6 5" marker-end="url(#ar-pink)"/>
+
+  <rect x="545" y="404" width="300" height="86" rx="9" fill="#2a1220" stroke="#ff006e" stroke-width="2.8"/>
+  <text x="695" y="431" fill="#ffd7e6" font-size="14.5" font-weight="700" text-anchor="middle">IntegrityStats</text>
+  <text x="695" y="453" fill="#f8b4ce" font-size="12.5" text-anchor="middle">drift against hallucination,</text>
+  <text x="695" y="472" fill="#f8b4ce" font-size="12.5" text-anchor="middle">reported as a rate per step</text>
+
+  <path d="M 935 314 L 935 352 L 985 352 L 985 398" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#ar-slate)"/>
+
+  <rect x="905" y="404" width="150" height="86" rx="9" fill="#0d1b2a" stroke="#39ff14" stroke-width="2"/>
+  <text x="980" y="431" fill="#e2e8f0" font-size="14" font-weight="700" text-anchor="middle">FastAPI</text>
+  <text x="980" y="452" fill="#94a3b8" font-size="12" text-anchor="middle">/predict /metrics</text>
+  <text x="980" y="470" fill="#94a3b8" font-size="12" text-anchor="middle">/healthz</text>
+
+  <path d="M 1055 447 L 1084 447" stroke="#39ff14" stroke-width="2.2" fill="none" marker-end="url(#ar-green)"/>
+
+  <rect x="1090" y="404" width="90" height="86" rx="9" fill="#0d1b2a" stroke="#39ff14" stroke-width="2"/>
+  <text x="1135" y="437" fill="#e2e8f0" font-size="13" font-weight="700" text-anchor="middle">Prometheus</text>
+  <text x="1135" y="458" fill="#94a3b8" font-size="12.5" text-anchor="middle">+ Grafana</text>
+
+  <text x="30" y="440" fill="#64748b" font-size="12.5">Validators report</text>
+  <text x="30" y="459" fill="#64748b" font-size="12.5">and continue. They</text>
+  <text x="30" y="478" fill="#64748b" font-size="12.5">never halt a run.</text>
+</svg>

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,39 +1,39 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 1240" width="980" height="1240" role="img" aria-label="System map: configs/env.yaml feeds the DroneEnv, the PPO agent closes the loop, a validator band watches both sides and reports into IntegrityStats, and the policy is served behind FastAPI" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0.4" y2="1">
-    <stop offset="0" stop-color="#060a07"/>
-    <stop offset="0.55" stop-color="#040705"/>
-    <stop offset="1" stop-color="#030503"/>
+    <stop offset="0" stop-color="#0b120e"/>
+    <stop offset="0.55" stop-color="#070b08"/>
+    <stop offset="1" stop-color="#050805"/>
   </linearGradient>
   <pattern id="grid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#0d130f"/>
+    <circle cx="1" cy="1" r="0.7" fill="#121a14"/>
   </pattern>
   <linearGradient id="chrome" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#5a5f5c"/>
+    <stop offset="0" stop-color="#6d716f"/>
     <stop offset="0.28" stop-color="#e8ebe9"/>
-    <stop offset="0.5" stop-color="#888d8a"/>
+    <stop offset="0.5" stop-color="#9ba09d"/>
     <stop offset="0.72" stop-color="#fafbfa"/>
-    <stop offset="1" stop-color="#626764"/>
+    <stop offset="1" stop-color="#767b78"/>
   </linearGradient>
   <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#10160f"/>
-    <stop offset="0.5" stop-color="#0d120e"/>
-    <stop offset="1" stop-color="#0b0f0c"/>
+    <stop offset="0" stop-color="#172018"/>
+    <stop offset="0.5" stop-color="#131a14"/>
+    <stop offset="1" stop-color="#0f1510"/>
   </linearGradient>
   <linearGradient id="panelLive" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#18211a"/>
-    <stop offset="1" stop-color="#0d120e"/>
+    <stop offset="0" stop-color="#202c23"/>
+    <stop offset="1" stop-color="#141c16"/>
   </linearGradient>
   <linearGradient id="edge" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#2e3830" stop-opacity="0.2"/>
+    <stop offset="0" stop-color="#454f47" stop-opacity="0.2"/>
     <stop offset="0.5" stop-color="#949a96" stop-opacity="0.75"/>
-    <stop offset="1" stop-color="#2e3830" stop-opacity="0.2"/>
+    <stop offset="1" stop-color="#454f47" stop-opacity="0.2"/>
   </linearGradient>
   <linearGradient id="spine" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#58916d" stop-opacity="0"/>
-    <stop offset="0.12" stop-color="#58916d" stop-opacity="0.55"/>
-    <stop offset="0.88" stop-color="#58916d" stop-opacity="0.55"/>
-    <stop offset="1" stop-color="#58916d" stop-opacity="0"/>
+    <stop offset="0" stop-color="#6faa85" stop-opacity="0"/>
+    <stop offset="0.12" stop-color="#6faa85" stop-opacity="0.55"/>
+    <stop offset="0.88" stop-color="#6faa85" stop-opacity="0.55"/>
+    <stop offset="1" stop-color="#6faa85" stop-opacity="0"/>
   </linearGradient>
   <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
     <path d="M0,0 L10,5 L0,10 z" fill="#949a96"/>
@@ -46,97 +46,97 @@
 <rect x="0" y="0" width="980" height="1240" fill="url(#bg)"/>
 <rect x="0" y="0" width="980" height="1240" fill="url(#grid)"/>
 
-<rect x="34" y="150" width="1" height="1010" fill="#1b221d"/>
+<rect x="34" y="150" width="1" height="1010" fill="#232d26"/>
 
-<text x="34" y="46" fill="#58916d" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SYSTEM MAP</text>
+<text x="34" y="46" fill="#6faa85" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SYSTEM MAP</text>
 <text x="34" y="88" fill="#f2f5f3" font-size="34" font-weight="700" letter-spacing="0.4">Architecture</text>
-<text x="34" y="118" fill="#878e89" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
-<rect x="700" y="30" width="2" height="62" fill="#232b25"/>
-<text x="946" y="52" fill="#8b928d" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
-<text x="946" y="78" fill="#8b928d" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
+<text x="34" y="118" fill="#939a95" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
+<rect x="700" y="30" width="2" height="62" fill="#333d36"/>
+<text x="946" y="52" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
+<text x="946" y="78" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
 
-<text x="62" y="170" fill="#58916d" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
-<text x="96" y="170" fill="#c4cac5" font-size="17" font-weight="700" letter-spacing="2.2">CONFIG</text>
-<text x="216" y="170" fill="#6b726d" font-size="18">the only file the code actually reads</text>
-<line x1="62" y1="184" x2="946" y2="184" stroke="#1b221d" stroke-width="1"/>
+<text x="62" y="170" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
+<text x="96" y="170" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">CONFIG</text>
+<text x="216" y="170" fill="#757c77" font-size="18">the only file the code actually reads</text>
+<line x1="62" y1="184" x2="946" y2="184" stroke="#222c25" stroke-width="1"/>
 
-<rect x="62" y="200" width="440" height="88" fill="url(#panel)" stroke="#2e3830" stroke-width="1.5"/>
+<rect x="62" y="200" width="440" height="88" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="74" y="200.7" width="416" height="1.4" fill="url(#edge)"/>
 <text x="84" y="236" fill="#ecefed" font-size="22" font-weight="700">configs/env.yaml</text>
-<text x="84" y="268" fill="#9aa19c" font-size="19" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid_size 20, max_steps 200</text>
+<text x="84" y="268" fill="#a5aca7" font-size="19" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid_size 20, max_steps 200</text>
 
-<text x="62" y="342" fill="#58916d" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">02</text>
-<text x="96" y="342" fill="#c4cac5" font-size="17" font-weight="700" letter-spacing="2.2">ENVIRONMENT</text>
-<text x="280" y="342" fill="#6b726d" font-size="18">DroneEnv, a gymnasium grid world</text>
-<line x1="62" y1="356" x2="946" y2="356" stroke="#1b221d" stroke-width="1"/>
+<text x="62" y="342" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">02</text>
+<text x="96" y="342" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">ENVIRONMENT</text>
+<text x="280" y="342" fill="#757c77" font-size="18">DroneEnv, a gymnasium grid world</text>
+<line x1="62" y1="356" x2="946" y2="356" stroke="#222c25" stroke-width="1"/>
 
-<rect x="62" y="372" width="420" height="152" fill="url(#panel)" stroke="#2e3830" stroke-width="1.5"/>
+<rect x="62" y="372" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="74" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="84" y="408" fill="#ecefed" font-size="22" font-weight="700">reset() and step(action)</text>
-<text x="84" y="442" fill="#9aa19c" font-size="19">returns obs, reward, terminated,</text>
-<text x="84" y="470" fill="#9aa19c" font-size="19">truncated, info</text>
-<text x="84" y="504" fill="#787f7a" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+10 at goal, -1 per step</text>
+<text x="84" y="442" fill="#a5aca7" font-size="19">returns obs, reward, terminated,</text>
+<text x="84" y="470" fill="#a5aca7" font-size="19">truncated, info</text>
+<text x="84" y="504" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+10 at goal, -1 per step</text>
 
-<rect x="526" y="372" width="420" height="152" fill="url(#panel)" stroke="#2e3830" stroke-width="1.5"/>
+<rect x="526" y="372" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="538" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="548" y="408" fill="#ecefed" font-size="22" font-weight="700">spaces</text>
-<text x="548" y="442" fill="#9aa19c" font-size="19">observation Box(5): x, y, goal x,</text>
-<text x="548" y="470" fill="#9aa19c" font-size="19">goal y, steps remaining</text>
-<text x="548" y="504" fill="#9aa19c" font-size="19">action Discrete(5), edge clamped</text>
+<text x="548" y="442" fill="#a5aca7" font-size="19">observation Box(5): x, y, goal x,</text>
+<text x="548" y="470" fill="#a5aca7" font-size="19">goal y, steps remaining</text>
+<text x="548" y="504" fill="#a5aca7" font-size="19">action Discrete(5), edge clamped</text>
 
 <path d="M 482 448 L 518 448" stroke="#949a96" stroke-width="2" fill="none" marker-end="url(#a)"/>
 
-<text x="62" y="578" fill="#58916d" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">03</text>
-<text x="96" y="578" fill="#c4cac5" font-size="17" font-weight="700" letter-spacing="2.2">AGENT</text>
-<text x="200" y="578" fill="#6b726d" font-size="18">PPOAgent, actor and critic on one trunk</text>
-<line x1="62" y1="592" x2="946" y2="592" stroke="#1b221d" stroke-width="1"/>
+<text x="62" y="578" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">03</text>
+<text x="96" y="578" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">AGENT</text>
+<text x="200" y="578" fill="#757c77" font-size="18">PPOAgent, actor and critic on one trunk</text>
+<line x1="62" y1="592" x2="946" y2="592" stroke="#222c25" stroke-width="1"/>
 
-<rect x="62" y="608" width="420" height="152" fill="url(#panel)" stroke="#2e3830" stroke-width="1.5"/>
+<rect x="62" y="608" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="74" y="608.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="84" y="644" fill="#ecefed" font-size="22" font-weight="700">PPOPolicy</text>
-<text x="84" y="678" fill="#9aa19c" font-size="19">shared Linear(5, 64) + ReLU</text>
-<text x="84" y="706" fill="#9aa19c" font-size="19">policy head (5), value head (1)</text>
-<text x="84" y="740" fill="#787f7a" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">sample training, argmax serving</text>
+<text x="84" y="678" fill="#a5aca7" font-size="19">shared Linear(5, 64) + ReLU</text>
+<text x="84" y="706" fill="#a5aca7" font-size="19">policy head (5), value head (1)</text>
+<text x="84" y="740" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">sample training, argmax serving</text>
 
-<rect x="526" y="608" width="420" height="152" fill="url(#panel)" stroke="#2e3830" stroke-width="1.5"/>
+<rect x="526" y="608" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="538" y="608.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="548" y="644" fill="#ecefed" font-size="22" font-weight="700">clipped surrogate update</text>
-<text x="548" y="678" fill="#9aa19c" font-size="19">policy, value and entropy terms</text>
-<text x="548" y="712" fill="#787f7a" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">eps_clip 0.2, gamma 0.99</text>
-<text x="548" y="740" fill="#787f7a" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Adam lr 3e-4, 3 epochs</text>
+<text x="548" y="678" fill="#a5aca7" font-size="19">policy, value and entropy terms</text>
+<text x="548" y="712" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">eps_clip 0.2, gamma 0.99</text>
+<text x="548" y="740" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Adam lr 3e-4, 3 epochs</text>
 
 <path d="M 482 684 L 518 684" stroke="#949a96" stroke-width="2" fill="none" marker-end="url(#a)"/>
 
 <text x="62" y="814" fill="#e8ebe9" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">04</text>
 <text x="96" y="814" fill="#ffffff" font-size="17" font-weight="700" letter-spacing="2.2">VALIDATORS</text>
-<text x="262" y="814" fill="#a4aba6" font-size="18">every step answers both questions; the subject of this repository</text>
-<line x1="62" y1="828" x2="946" y2="828" stroke="#37423a" stroke-width="1"/>
+<text x="262" y="814" fill="#aeb4af" font-size="18">every step answers both questions; the subject of this repository</text>
+<line x1="62" y1="828" x2="946" y2="828" stroke="#4a564d" stroke-width="1"/>
 
 <rect x="62" y="844" width="420" height="146" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="84" y="882" fill="#ffffff" font-size="22" font-weight="700">IntegrityValidator</text>
-<text x="84" y="916" fill="#c4cac5" font-size="19">observation inside its space?</text>
-<text x="84" y="944" fill="#c4cac5" font-size="19">action legal? reward finite?</text>
-<text x="84" y="972" fill="#838a85" font-size="17">on the environment side</text>
+<text x="84" y="916" fill="#ccd2ce" font-size="19">observation inside its space?</text>
+<text x="84" y="944" fill="#ccd2ce" font-size="19">action legal? reward finite?</text>
+<text x="84" y="972" fill="#8f968f" font-size="17">on the environment side</text>
 
 <rect x="526" y="844" width="420" height="146" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="548" y="882" fill="#ffffff" font-size="22" font-weight="700">PolicyIntegrityValidator</text>
-<text x="548" y="916" fill="#c4cac5" font-size="19">probabilities sum to 1?</text>
-<text x="548" y="944" fill="#c4cac5" font-size="19">value finite? action in space?</text>
-<text x="548" y="972" fill="#838a85" font-size="17">on the agent side</text>
+<text x="548" y="916" fill="#ccd2ce" font-size="19">probabilities sum to 1?</text>
+<text x="548" y="944" fill="#ccd2ce" font-size="19">value finite? action in space?</text>
+<text x="548" y="972" fill="#8f968f" font-size="17">on the agent side</text>
 
 <path d="M 482 910 L 518 910" stroke="#e8ebe9" stroke-width="2.2" fill="none" marker-end="url(#ab)"/>
 
 <rect x="62" y="1010" width="884" height="86" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="84" y="1046" fill="#ffffff" font-size="22" font-weight="700">IntegrityStats</text>
-<text x="84" y="1078" fill="#c4cac5" font-size="19">drift against hallucination, reported as a rate per step, never as a bare count</text>
+<text x="84" y="1078" fill="#ccd2ce" font-size="19">drift against hallucination, reported as a rate per step, never as a bare count</text>
 
-<text x="62" y="1150" fill="#58916d" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">05</text>
-<text x="96" y="1150" fill="#c4cac5" font-size="17" font-weight="700" letter-spacing="2.2">SERVING</text>
-<text x="222" y="1150" fill="#6b726d" font-size="18">validators report, but never halt a run</text>
-<line x1="62" y1="1164" x2="946" y2="1164" stroke="#1b221d" stroke-width="1"/>
+<text x="62" y="1150" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">05</text>
+<text x="96" y="1150" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">SERVING</text>
+<text x="222" y="1150" fill="#757c77" font-size="18">validators report, but never halt a run</text>
+<line x1="62" y1="1164" x2="946" y2="1164" stroke="#222c25" stroke-width="1"/>
 
-<rect x="62" y="1180" width="420" height="34" fill="url(#panel)" stroke="#2e3830" stroke-width="1.4"/>
-<text x="84" y="1203" fill="#9aa19c" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FastAPI /predict /metrics /healthz</text>
-<rect x="526" y="1180" width="420" height="34" fill="url(#panel)" stroke="#2e3830" stroke-width="1.4"/>
-<text x="548" y="1203" fill="#9aa19c" font-size="18">Prometheus and Grafana scrape /metrics</text>
+<rect x="62" y="1180" width="420" height="34" fill="url(#panel)" stroke="#47514a" stroke-width="1.4"/>
+<text x="84" y="1203" fill="#a5aca7" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FastAPI /predict /metrics /healthz</text>
+<rect x="526" y="1180" width="420" height="34" fill="url(#panel)" stroke="#47514a" stroke-width="1.4"/>
+<text x="548" y="1203" fill="#a5aca7" font-size="18">Prometheus and Grafana scrape /metrics</text>
 </svg>

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -6,7 +6,7 @@
     <stop offset="1" stop-color="#05080c"/>
   </linearGradient>
   <pattern id="grid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#16202c"/>
+    <circle cx="1" cy="1" r="0.7" fill="#131b25"/>
   </pattern>
   <linearGradient id="chrome" x1="0" y1="0" x2="1" y2="0">
     <stop offset="0" stop-color="#5d6b7d"/>
@@ -30,10 +30,10 @@
     <stop offset="1" stop-color="#3d4d61" stop-opacity="0.2"/>
   </linearGradient>
   <linearGradient id="spine" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#7fd4ff" stop-opacity="0"/>
-    <stop offset="0.12" stop-color="#7fd4ff" stop-opacity="0.55"/>
-    <stop offset="0.88" stop-color="#7fd4ff" stop-opacity="0.55"/>
-    <stop offset="1" stop-color="#7fd4ff" stop-opacity="0"/>
+    <stop offset="0" stop-color="#8ab0cf" stop-opacity="0"/>
+    <stop offset="0.12" stop-color="#8ab0cf" stop-opacity="0.55"/>
+    <stop offset="0.88" stop-color="#8ab0cf" stop-opacity="0.55"/>
+    <stop offset="1" stop-color="#8ab0cf" stop-opacity="0"/>
   </linearGradient>
   <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
     <path d="M0,0 L10,5 L0,10 z" fill="#8fa3ba"/>
@@ -43,41 +43,41 @@
   </marker>
 </defs>
 
-<rect x="0" y="0" width="980" height="1240" rx="14" fill="url(#bg)"/>
-<rect x="0" y="0" width="980" height="1240" rx="14" fill="url(#grid)"/>
+<rect x="0" y="0" width="980" height="1240" fill="url(#bg)"/>
+<rect x="0" y="0" width="980" height="1240" fill="url(#grid)"/>
 
-<rect x="34" y="150" width="2" height="1010" fill="url(#spine)"/>
+<rect x="34" y="150" width="1" height="1010" fill="#243040"/>
 
-<text x="34" y="46" fill="#7fd4ff" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SYSTEM MAP</text>
+<text x="34" y="46" fill="#8ab0cf" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SYSTEM MAP</text>
 <text x="34" y="88" fill="#f4f8fc" font-size="34" font-weight="700" letter-spacing="0.4">Architecture</text>
 <text x="34" y="118" fill="#8ea0b5" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
 <rect x="700" y="30" width="2" height="62" fill="#2b3949"/>
 <text x="946" y="52" fill="#93a6bb" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
 <text x="946" y="78" fill="#93a6bb" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
 
-<text x="62" y="170" fill="#7fd4ff" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
+<text x="62" y="170" fill="#8ab0cf" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
 <text x="96" y="170" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">CONFIG</text>
 <text x="216" y="170" fill="#6d7d90" font-size="18">the only file the code actually reads</text>
 <line x1="62" y1="184" x2="946" y2="184" stroke="#1e2a37" stroke-width="1"/>
 
-<rect x="62" y="200" width="440" height="88" rx="6" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="62" y="200" width="440" height="88" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
 <rect x="74" y="200.7" width="416" height="1.4" fill="url(#edge)"/>
 <text x="84" y="236" fill="#eef4fa" font-size="22" font-weight="700">configs/env.yaml</text>
 <text x="84" y="268" fill="#9fb0c3" font-size="19" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid_size 20, max_steps 200</text>
 
-<text x="62" y="342" fill="#7fd4ff" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">02</text>
+<text x="62" y="342" fill="#8ab0cf" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">02</text>
 <text x="96" y="342" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">ENVIRONMENT</text>
 <text x="280" y="342" fill="#6d7d90" font-size="18">DroneEnv, a gymnasium grid world</text>
 <line x1="62" y1="356" x2="946" y2="356" stroke="#1e2a37" stroke-width="1"/>
 
-<rect x="62" y="372" width="420" height="152" rx="6" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="62" y="372" width="420" height="152" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
 <rect x="74" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="84" y="408" fill="#eef4fa" font-size="22" font-weight="700">reset() and step(action)</text>
 <text x="84" y="442" fill="#9fb0c3" font-size="19">returns obs, reward, terminated,</text>
 <text x="84" y="470" fill="#9fb0c3" font-size="19">truncated, info</text>
 <text x="84" y="504" fill="#7f92a8" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+10 at goal, -1 per step</text>
 
-<rect x="526" y="372" width="420" height="152" rx="6" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="526" y="372" width="420" height="152" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
 <rect x="538" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="548" y="408" fill="#eef4fa" font-size="22" font-weight="700">spaces</text>
 <text x="548" y="442" fill="#9fb0c3" font-size="19">observation Box(5): x, y, goal x,</text>
@@ -86,19 +86,19 @@
 
 <path d="M 482 448 L 518 448" stroke="#8fa3ba" stroke-width="2" fill="none" marker-end="url(#a)"/>
 
-<text x="62" y="578" fill="#7fd4ff" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">03</text>
+<text x="62" y="578" fill="#8ab0cf" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">03</text>
 <text x="96" y="578" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">AGENT</text>
 <text x="200" y="578" fill="#6d7d90" font-size="18">PPOAgent, actor and critic on one trunk</text>
 <line x1="62" y1="592" x2="946" y2="592" stroke="#1e2a37" stroke-width="1"/>
 
-<rect x="62" y="608" width="420" height="152" rx="6" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="62" y="608" width="420" height="152" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
 <rect x="74" y="608.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="84" y="644" fill="#eef4fa" font-size="22" font-weight="700">PPOPolicy</text>
 <text x="84" y="678" fill="#9fb0c3" font-size="19">shared Linear(5, 64) + ReLU</text>
 <text x="84" y="706" fill="#9fb0c3" font-size="19">policy head (5), value head (1)</text>
 <text x="84" y="740" fill="#7f92a8" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">sample training, argmax serving</text>
 
-<rect x="526" y="608" width="420" height="152" rx="6" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="526" y="608" width="420" height="152" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
 <rect x="538" y="608.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="548" y="644" fill="#eef4fa" font-size="22" font-weight="700">clipped surrogate update</text>
 <text x="548" y="678" fill="#9fb0c3" font-size="19">policy, value and entropy terms</text>
@@ -112,17 +112,13 @@
 <text x="262" y="814" fill="#a9bbcd" font-size="18">every step answers both questions; the subject of this repository</text>
 <line x1="62" y1="828" x2="946" y2="828" stroke="#42566b" stroke-width="1"/>
 
-<rect x="62" y="844" width="420" height="146" rx="6" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
-<path d="M 74 858 L 74 846 L 86 846" stroke="#7fd4ff" stroke-width="2" fill="none"/>
-<path d="M 470 976 L 470 988 L 458 988" stroke="#7fd4ff" stroke-width="2" fill="none"/>
+<rect x="62" y="844" width="420" height="146" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="84" y="882" fill="#ffffff" font-size="22" font-weight="700">IntegrityValidator</text>
 <text x="84" y="916" fill="#ccd9e7" font-size="19">observation inside its space?</text>
 <text x="84" y="944" fill="#ccd9e7" font-size="19">action legal? reward finite?</text>
 <text x="84" y="972" fill="#8ba0b6" font-size="17">on the environment side</text>
 
-<rect x="526" y="844" width="420" height="146" rx="6" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
-<path d="M 538 858 L 538 846 L 550 846" stroke="#7fd4ff" stroke-width="2" fill="none"/>
-<path d="M 934 976 L 934 988 L 922 988" stroke="#7fd4ff" stroke-width="2" fill="none"/>
+<rect x="526" y="844" width="420" height="146" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="548" y="882" fill="#ffffff" font-size="22" font-weight="700">PolicyIntegrityValidator</text>
 <text x="548" y="916" fill="#ccd9e7" font-size="19">probabilities sum to 1?</text>
 <text x="548" y="944" fill="#ccd9e7" font-size="19">value finite? action in space?</text>
@@ -130,17 +126,17 @@
 
 <path d="M 482 910 L 518 910" stroke="#eaf2fa" stroke-width="2.2" fill="none" marker-end="url(#ab)"/>
 
-<rect x="62" y="1010" width="884" height="86" rx="6" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
+<rect x="62" y="1010" width="884" height="86" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="84" y="1046" fill="#ffffff" font-size="22" font-weight="700">IntegrityStats</text>
 <text x="84" y="1078" fill="#ccd9e7" font-size="19">drift against hallucination, reported as a rate per step, never as a bare count</text>
 
-<text x="62" y="1150" fill="#7fd4ff" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">05</text>
+<text x="62" y="1150" fill="#8ab0cf" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">05</text>
 <text x="96" y="1150" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">SERVING</text>
 <text x="222" y="1150" fill="#6d7d90" font-size="18">validators report, but never halt a run</text>
 <line x1="62" y1="1164" x2="946" y2="1164" stroke="#1e2a37" stroke-width="1"/>
 
-<rect x="62" y="1180" width="420" height="34" rx="5" fill="url(#panel)" stroke="#3a4859" stroke-width="1.4"/>
+<rect x="62" y="1180" width="420" height="34" fill="url(#panel)" stroke="#3a4859" stroke-width="1.4"/>
 <text x="84" y="1203" fill="#9fb0c3" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FastAPI /predict /metrics /healthz</text>
-<rect x="526" y="1180" width="420" height="34" rx="5" fill="url(#panel)" stroke="#3a4859" stroke-width="1.4"/>
+<rect x="526" y="1180" width="420" height="34" fill="url(#panel)" stroke="#3a4859" stroke-width="1.4"/>
 <text x="548" y="1203" fill="#9fb0c3" font-size="18">Prometheus and Grafana scrape /metrics</text>
 </svg>

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,87 +1,127 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 520" width="1200" height="520" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
-  <defs>
-    <marker id="ar-cyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#00d4ff"/>
-    </marker>
-    <marker id="ar-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b537f2"/>
-    </marker>
-    <marker id="ar-pink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#ff006e"/>
-    </marker>
-    <marker id="ar-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#39ff14"/>
-    </marker>
-    <marker id="ar-slate" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 856" width="980" height="856" role="img" aria-label="Architecture: config feeds the DroneEnv, the PPO agent closes the loop, a validator band watches both sides, and the policy is served behind FastAPI" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#12161d"/>
+    <stop offset="1" stop-color="#0a0d12"/>
+  </linearGradient>
+  <linearGradient id="chrome" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#8d99a8"/>
+    <stop offset="0.35" stop-color="#e6edf5"/>
+    <stop offset="0.62" stop-color="#9aa6b5"/>
+    <stop offset="1" stop-color="#dfe7f0"/>
+  </linearGradient>
+  <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#1e242e"/>
+    <stop offset="1" stop-color="#151a22"/>
+  </linearGradient>
+  <linearGradient id="panelLive" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#28303c"/>
+    <stop offset="1" stop-color="#1b212a"/>
+  </linearGradient>
+  <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+    <path d="M0,0 L10,5 L0,10 z" fill="#aab6c6"/>
+  </marker>
+  <marker id="ab" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+    <path d="M0,0 L10,5 L0,10 z" fill="#e6edf5"/>
+  </marker>
+</defs>
 
-  <rect x="0" y="0" width="1200" height="520" rx="14" fill="#0a1422"/>
+<rect x="0" y="0" width="980" height="856" rx="12" fill="url(#bg)"/>
 
-  <text x="30" y="38" fill="#e2e8f0" font-size="19" font-weight="700">PPO control loop</text>
-  <text x="215" y="38" fill="#94a3b8" font-size="15">the validator layer is in pink; everything else is scaffolding around it</text>
+<text x="34" y="52" fill="#f2f6fa" font-size="27" font-weight="700" letter-spacing="0.2">Architecture</text>
+<text x="34" y="79" fill="#93a1b3" font-size="15.5">One control loop, top to bottom. The bright band is the part that watches.</text>
+<text x="946" y="52" fill="#8f9dae" font-size="14.5" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
+<text x="946" y="76" fill="#8f9dae" font-size="14.5" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
 
-  <rect x="20" y="130" width="190" height="76" rx="9" fill="#0d1b2a" stroke="#38bdf8" stroke-width="2"/>
-  <text x="115" y="162" fill="#e2e8f0" font-size="14.5" font-weight="700" text-anchor="middle">configs/env.yaml</text>
-  <text x="115" y="184" fill="#94a3b8" font-size="12.5" text-anchor="middle">grid 20x20, 200 max steps</text>
+<line x1="34" y1="100" x2="946" y2="100" stroke="#2b333f" stroke-width="1"/>
 
-  <rect x="250" y="62" width="360" height="252" rx="12" fill="#0d1f30" stroke="#00d4ff" stroke-width="2"/>
-  <text x="270" y="88" fill="#7dd3fc" font-size="15.5" font-weight="700">DroneEnv (gymnasium)</text>
+<text x="34" y="132" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6">CONFIG</text>
+<text x="150" y="132" fill="#6f7c8d" font-size="15">the only file the code actually reads</text>
+<rect x="34" y="146" width="330" height="72" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="52" y="174" fill="#e9eff6" font-size="18" font-weight="700">configs/env.yaml</text>
+<text x="52" y="199" fill="#9dabbc" font-size="15.5">grid_size 20, max_steps 200</text>
 
-  <rect x="270" y="102" width="320" height="86" rx="8" fill="#132a3f" stroke="#00d4ff" stroke-width="1.6"/>
-  <text x="430" y="127" fill="#e2e8f0" font-size="14" font-weight="700" text-anchor="middle">reset() and step(action)</text>
-  <text x="430" y="149" fill="#94a3b8" font-size="12.5" text-anchor="middle">obs, reward, terminated,</text>
-  <text x="430" y="168" fill="#94a3b8" font-size="12.5" text-anchor="middle">truncated, info</text>
+<line x1="34" y1="244" x2="946" y2="244" stroke="#2b333f" stroke-width="1"/>
 
-  <rect x="270" y="206" width="320" height="90" rx="8" fill="#2a1220" stroke="#ff006e" stroke-width="2.4"/>
-  <text x="430" y="231" fill="#ffd7e6" font-size="14" font-weight="700" text-anchor="middle">IntegrityValidator</text>
-  <text x="430" y="253" fill="#f8b4ce" font-size="12.5" text-anchor="middle">observation inside its space?</text>
-  <text x="430" y="272" fill="#f8b4ce" font-size="12.5" text-anchor="middle">action legal? reward finite?</text>
+<text x="34" y="276" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6">ENVIRONMENT</text>
+<text x="185" y="276" fill="#6f7c8d" font-size="15">DroneEnv, a gymnasium grid world</text>
+<rect x="34" y="290" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="52" y="318" fill="#e9eff6" font-size="18" font-weight="700">reset() and step(action)</text>
+<text x="52" y="342" fill="#9dabbc" font-size="15.5">returns obs, reward,</text>
+<text x="52" y="364" fill="#9dabbc" font-size="15.5">terminated, truncated, info</text>
 
-  <rect x="700" y="62" width="470" height="252" rx="12" fill="#181f38" stroke="#b537f2" stroke-width="2"/>
-  <text x="720" y="88" fill="#d8b4fe" font-size="15.5" font-weight="700">PPOAgent (PyTorch)</text>
+<rect x="347" y="290" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="365" y="318" fill="#e9eff6" font-size="18" font-weight="700">observation, Box(5)</text>
+<text x="365" y="342" fill="#9dabbc" font-size="15.5">x, y, goal x, goal y,</text>
+<text x="365" y="364" fill="#9dabbc" font-size="15.5">steps remaining</text>
 
-  <rect x="720" y="102" width="430" height="86" rx="8" fill="#1b263b" stroke="#b537f2" stroke-width="1.6"/>
-  <text x="935" y="127" fill="#e2e8f0" font-size="14" font-weight="700" text-anchor="middle">PPOPolicy</text>
-  <text x="935" y="149" fill="#94a3b8" font-size="12.5" text-anchor="middle">shared Linear(5, 64) + ReLU</text>
-  <text x="935" y="168" fill="#94a3b8" font-size="12.5" text-anchor="middle">policy head (5), value head (1)</text>
+<rect x="660" y="290" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="678" y="318" fill="#e9eff6" font-size="18" font-weight="700">action, Discrete(5)</text>
+<text x="678" y="342" fill="#9dabbc" font-size="15.5">hover, up, down, left, right</text>
+<text x="678" y="364" fill="#9dabbc" font-size="15.5">clamped at the grid edge</text>
 
-  <rect x="720" y="206" width="430" height="90" rx="8" fill="#2a1220" stroke="#ff006e" stroke-width="2.4"/>
-  <text x="935" y="231" fill="#ffd7e6" font-size="14" font-weight="700" text-anchor="middle">PolicyIntegrityValidator</text>
-  <text x="935" y="253" fill="#f8b4ce" font-size="12.5" text-anchor="middle">probabilities sum to 1? value finite?</text>
-  <text x="935" y="272" fill="#f8b4ce" font-size="12.5" text-anchor="middle">chosen action inside the space?</text>
+<line x1="34" y1="402" x2="946" y2="402" stroke="#2b333f" stroke-width="1"/>
 
-  <path d="M 210 168 L 244 168" stroke="#38bdf8" stroke-width="2.2" fill="none" marker-end="url(#ar-cyan)"/>
+<text x="34" y="434" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6">AGENT</text>
+<text x="130" y="434" fill="#6f7c8d" font-size="15">PPOAgent, actor and critic on one trunk</text>
+<rect x="34" y="448" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="52" y="476" fill="#e9eff6" font-size="18" font-weight="700">PPOPolicy</text>
+<text x="52" y="500" fill="#9dabbc" font-size="15.5">shared Linear(5, 64) + ReLU</text>
+<text x="52" y="522" fill="#9dabbc" font-size="15.5">policy head (5), value head (1)</text>
 
-  <path d="M 610 126 L 694 126" stroke="#00d4ff" stroke-width="2.4" fill="none" marker-end="url(#ar-cyan)"/>
-  <text x="652" y="116" fill="#7dd3fc" font-size="12.5" font-weight="600" text-anchor="middle">observation</text>
+<rect x="347" y="448" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="365" y="476" fill="#e9eff6" font-size="18" font-weight="700">clipped surrogate update</text>
+<text x="365" y="500" fill="#9dabbc" font-size="15.5">eps_clip 0.2, gamma 0.99</text>
+<text x="365" y="522" fill="#9dabbc" font-size="15.5">Adam lr 3e-4, 3 epochs</text>
 
-  <path d="M 700 168 L 616 168" stroke="#b537f2" stroke-width="2.4" fill="none" marker-end="url(#ar-purple)"/>
-  <text x="658" y="158" fill="#d8b4fe" font-size="12.5" font-weight="600" text-anchor="middle">action</text>
+<rect x="660" y="448" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="678" y="476" fill="#e9eff6" font-size="18" font-weight="700">select_action / predict</text>
+<text x="678" y="500" fill="#9dabbc" font-size="15.5">sample while training,</text>
+<text x="678" y="522" fill="#9dabbc" font-size="15.5">argmax at inference</text>
 
-  <path d="M 430 296 C 430 360, 560 372, 606 400" stroke="#ff006e" stroke-width="2" fill="none" stroke-dasharray="6 5" marker-end="url(#ar-pink)"/>
-  <path d="M 935 296 C 935 360, 830 372, 784 400" stroke="#ff006e" stroke-width="2" fill="none" stroke-dasharray="6 5" marker-end="url(#ar-pink)"/>
+<path d="M 320 333 L 341 333" stroke="#aab6c6" stroke-width="1.8" fill="none" marker-end="url(#a)"/>
+<path d="M 633 333 L 654 333" stroke="#aab6c6" stroke-width="1.8" fill="none" marker-end="url(#a)"/>
+<path d="M 320 491 L 341 491" stroke="#aab6c6" stroke-width="1.8" fill="none" marker-end="url(#a)"/>
+<path d="M 633 491 L 654 491" stroke="#aab6c6" stroke-width="1.8" fill="none" marker-end="url(#a)"/>
 
-  <rect x="545" y="404" width="300" height="86" rx="9" fill="#2a1220" stroke="#ff006e" stroke-width="2.8"/>
-  <text x="695" y="431" fill="#ffd7e6" font-size="14.5" font-weight="700" text-anchor="middle">IntegrityStats</text>
-  <text x="695" y="453" fill="#f8b4ce" font-size="12.5" text-anchor="middle">drift against hallucination,</text>
-  <text x="695" y="472" fill="#f8b4ce" font-size="12.5" text-anchor="middle">reported as a rate per step</text>
 
-  <path d="M 935 314 L 935 352 L 985 352 L 985 398" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#ar-slate)"/>
+<line x1="34" y1="560" x2="946" y2="560" stroke="#2b333f" stroke-width="1"/>
 
-  <rect x="905" y="404" width="150" height="86" rx="9" fill="#0d1b2a" stroke="#39ff14" stroke-width="2"/>
-  <text x="980" y="431" fill="#e2e8f0" font-size="14" font-weight="700" text-anchor="middle">FastAPI</text>
-  <text x="980" y="452" fill="#94a3b8" font-size="12" text-anchor="middle">/predict /metrics</text>
-  <text x="980" y="470" fill="#94a3b8" font-size="12" text-anchor="middle">/healthz</text>
+<text x="34" y="592" fill="#e6edf5" font-size="14" font-weight="700" letter-spacing="1.6">VALIDATORS</text>
+<text x="168" y="592" fill="#aab6c6" font-size="15">every step answers both questions; this is the subject of the repository</text>
+<rect x="34" y="606" width="286" height="96" rx="8" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.4"/>
+<text x="52" y="634" fill="#ffffff" font-size="18" font-weight="700">IntegrityValidator</text>
+<text x="52" y="658" fill="#c3cedd" font-size="15.5">observation inside its space?</text>
+<text x="52" y="680" fill="#c3cedd" font-size="15.5">action legal? reward finite?</text>
 
-  <path d="M 1055 447 L 1084 447" stroke="#39ff14" stroke-width="2.2" fill="none" marker-end="url(#ar-green)"/>
+<rect x="347" y="606" width="286" height="96" rx="8" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.4"/>
+<text x="365" y="634" fill="#ffffff" font-size="18" font-weight="700">PolicyIntegrityValidator</text>
+<text x="365" y="658" fill="#c3cedd" font-size="15.5">probabilities sum to 1?</text>
+<text x="365" y="680" fill="#c3cedd" font-size="15.5">value finite? action in space?</text>
 
-  <rect x="1090" y="404" width="90" height="86" rx="9" fill="#0d1b2a" stroke="#39ff14" stroke-width="2"/>
-  <text x="1135" y="437" fill="#e2e8f0" font-size="13" font-weight="700" text-anchor="middle">Prometheus</text>
-  <text x="1135" y="458" fill="#94a3b8" font-size="12.5" text-anchor="middle">+ Grafana</text>
+<rect x="660" y="606" width="286" height="96" rx="8" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.4"/>
+<text x="678" y="634" fill="#ffffff" font-size="18" font-weight="700">IntegrityStats</text>
+<text x="678" y="658" fill="#c3cedd" font-size="15.5">drift against hallucination,</text>
+<text x="678" y="680" fill="#c3cedd" font-size="15.5">as a rate per step</text>
 
-  <text x="30" y="440" fill="#64748b" font-size="12.5">Validators report</text>
-  <text x="30" y="459" fill="#64748b" font-size="12.5">and continue. They</text>
-  <text x="30" y="478" fill="#64748b" font-size="12.5">never halt a run.</text>
+<path d="M 320 654 L 341 654" stroke="#e6edf5" stroke-width="2" fill="none" marker-end="url(#ab)"/>
+<path d="M 633 654 L 654 654" stroke="#e6edf5" stroke-width="2" fill="none" marker-end="url(#ab)"/>
+
+<line x1="34" y1="728" x2="946" y2="728" stroke="#2b333f" stroke-width="1"/>
+
+<text x="34" y="760" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6">SERVING</text>
+<text x="152" y="760" fill="#6f7c8d" font-size="15">weights load once at startup; validators report but never halt a run</text>
+<rect x="34" y="774" width="286" height="62" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="52" y="800" fill="#e9eff6" font-size="18" font-weight="700">FastAPI</text>
+<text x="52" y="824" fill="#9dabbc" font-size="14.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">/predict /metrics /healthz</text>
+
+<rect x="347" y="774" width="286" height="62" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="365" y="800" fill="#e9eff6" font-size="18" font-weight="700">Prometheus + Grafana</text>
+<text x="365" y="824" fill="#9dabbc" font-size="15.5">scrapes /metrics</text>
+
+<rect x="660" y="774" width="286" height="62" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="678" y="800" fill="#e9eff6" font-size="18" font-weight="700">models/ppo_drone.pt</text>
+<text x="678" y="824" fill="#9dabbc" font-size="15.5">loaded at startup</text>
+
+<path d="M 320 805 L 341 805" stroke="#aab6c6" stroke-width="1.8" fill="none" marker-end="url(#a)"/>
 </svg>

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,39 +1,39 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 1240" width="980" height="1240" role="img" aria-label="System map: configs/env.yaml feeds the DroneEnv, the PPO agent closes the loop, a validator band watches both sides and reports into IntegrityStats, and the policy is served behind FastAPI" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0.4" y2="1">
-    <stop offset="0" stop-color="#0b120e"/>
-    <stop offset="0.55" stop-color="#070b08"/>
-    <stop offset="1" stop-color="#050805"/>
+    <stop offset="0" stop-color="#060a07"/>
+    <stop offset="0.55" stop-color="#040705"/>
+    <stop offset="1" stop-color="#030503"/>
   </linearGradient>
   <pattern id="grid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#121a14"/>
+    <circle cx="1" cy="1" r="0.7" fill="#0d130f"/>
   </pattern>
   <linearGradient id="chrome" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#6d716f"/>
+    <stop offset="0" stop-color="#5a5f5c"/>
     <stop offset="0.28" stop-color="#e8ebe9"/>
-    <stop offset="0.5" stop-color="#9ba09d"/>
+    <stop offset="0.5" stop-color="#888d8a"/>
     <stop offset="0.72" stop-color="#fafbfa"/>
-    <stop offset="1" stop-color="#767b78"/>
+    <stop offset="1" stop-color="#626764"/>
   </linearGradient>
   <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#172018"/>
-    <stop offset="0.5" stop-color="#131a14"/>
-    <stop offset="1" stop-color="#0f1510"/>
+    <stop offset="0" stop-color="#10160f"/>
+    <stop offset="0.5" stop-color="#0d120e"/>
+    <stop offset="1" stop-color="#0b0f0c"/>
   </linearGradient>
   <linearGradient id="panelLive" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#202c23"/>
-    <stop offset="1" stop-color="#141c16"/>
+    <stop offset="0" stop-color="#18211a"/>
+    <stop offset="1" stop-color="#0d120e"/>
   </linearGradient>
   <linearGradient id="edge" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#454f47" stop-opacity="0.2"/>
+    <stop offset="0" stop-color="#2e3830" stop-opacity="0.2"/>
     <stop offset="0.5" stop-color="#949a96" stop-opacity="0.75"/>
-    <stop offset="1" stop-color="#454f47" stop-opacity="0.2"/>
+    <stop offset="1" stop-color="#2e3830" stop-opacity="0.2"/>
   </linearGradient>
   <linearGradient id="spine" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#6faa85" stop-opacity="0"/>
-    <stop offset="0.12" stop-color="#6faa85" stop-opacity="0.55"/>
-    <stop offset="0.88" stop-color="#6faa85" stop-opacity="0.55"/>
-    <stop offset="1" stop-color="#6faa85" stop-opacity="0"/>
+    <stop offset="0" stop-color="#58916d" stop-opacity="0"/>
+    <stop offset="0.12" stop-color="#58916d" stop-opacity="0.55"/>
+    <stop offset="0.88" stop-color="#58916d" stop-opacity="0.55"/>
+    <stop offset="1" stop-color="#58916d" stop-opacity="0"/>
   </linearGradient>
   <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
     <path d="M0,0 L10,5 L0,10 z" fill="#949a96"/>
@@ -46,97 +46,97 @@
 <rect x="0" y="0" width="980" height="1240" fill="url(#bg)"/>
 <rect x="0" y="0" width="980" height="1240" fill="url(#grid)"/>
 
-<rect x="34" y="150" width="1" height="1010" fill="#232d26"/>
+<rect x="34" y="150" width="1" height="1010" fill="#1b221d"/>
 
-<text x="34" y="46" fill="#6faa85" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SYSTEM MAP</text>
+<text x="34" y="46" fill="#58916d" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SYSTEM MAP</text>
 <text x="34" y="88" fill="#f2f5f3" font-size="34" font-weight="700" letter-spacing="0.4">Architecture</text>
-<text x="34" y="118" fill="#939a95" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
-<rect x="700" y="30" width="2" height="62" fill="#333d36"/>
-<text x="946" y="52" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
-<text x="946" y="78" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
+<text x="34" y="118" fill="#878e89" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
+<rect x="700" y="30" width="2" height="62" fill="#232b25"/>
+<text x="946" y="52" fill="#8b928d" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
+<text x="946" y="78" fill="#8b928d" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
 
-<text x="62" y="170" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
-<text x="96" y="170" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">CONFIG</text>
-<text x="216" y="170" fill="#757c77" font-size="18">the only file the code actually reads</text>
-<line x1="62" y1="184" x2="946" y2="184" stroke="#222c25" stroke-width="1"/>
+<text x="62" y="170" fill="#58916d" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
+<text x="96" y="170" fill="#c4cac5" font-size="17" font-weight="700" letter-spacing="2.2">CONFIG</text>
+<text x="216" y="170" fill="#6b726d" font-size="18">the only file the code actually reads</text>
+<line x1="62" y1="184" x2="946" y2="184" stroke="#1b221d" stroke-width="1"/>
 
-<rect x="62" y="200" width="440" height="88" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
+<rect x="62" y="200" width="440" height="88" fill="url(#panel)" stroke="#2e3830" stroke-width="1.5"/>
 <rect x="74" y="200.7" width="416" height="1.4" fill="url(#edge)"/>
 <text x="84" y="236" fill="#ecefed" font-size="22" font-weight="700">configs/env.yaml</text>
-<text x="84" y="268" fill="#a5aca7" font-size="19" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid_size 20, max_steps 200</text>
+<text x="84" y="268" fill="#9aa19c" font-size="19" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid_size 20, max_steps 200</text>
 
-<text x="62" y="342" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">02</text>
-<text x="96" y="342" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">ENVIRONMENT</text>
-<text x="280" y="342" fill="#757c77" font-size="18">DroneEnv, a gymnasium grid world</text>
-<line x1="62" y1="356" x2="946" y2="356" stroke="#222c25" stroke-width="1"/>
+<text x="62" y="342" fill="#58916d" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">02</text>
+<text x="96" y="342" fill="#c4cac5" font-size="17" font-weight="700" letter-spacing="2.2">ENVIRONMENT</text>
+<text x="280" y="342" fill="#6b726d" font-size="18">DroneEnv, a gymnasium grid world</text>
+<line x1="62" y1="356" x2="946" y2="356" stroke="#1b221d" stroke-width="1"/>
 
-<rect x="62" y="372" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
+<rect x="62" y="372" width="420" height="152" fill="url(#panel)" stroke="#2e3830" stroke-width="1.5"/>
 <rect x="74" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="84" y="408" fill="#ecefed" font-size="22" font-weight="700">reset() and step(action)</text>
-<text x="84" y="442" fill="#a5aca7" font-size="19">returns obs, reward, terminated,</text>
-<text x="84" y="470" fill="#a5aca7" font-size="19">truncated, info</text>
-<text x="84" y="504" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+10 at goal, -1 per step</text>
+<text x="84" y="442" fill="#9aa19c" font-size="19">returns obs, reward, terminated,</text>
+<text x="84" y="470" fill="#9aa19c" font-size="19">truncated, info</text>
+<text x="84" y="504" fill="#787f7a" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+10 at goal, -1 per step</text>
 
-<rect x="526" y="372" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
+<rect x="526" y="372" width="420" height="152" fill="url(#panel)" stroke="#2e3830" stroke-width="1.5"/>
 <rect x="538" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="548" y="408" fill="#ecefed" font-size="22" font-weight="700">spaces</text>
-<text x="548" y="442" fill="#a5aca7" font-size="19">observation Box(5): x, y, goal x,</text>
-<text x="548" y="470" fill="#a5aca7" font-size="19">goal y, steps remaining</text>
-<text x="548" y="504" fill="#a5aca7" font-size="19">action Discrete(5), edge clamped</text>
+<text x="548" y="442" fill="#9aa19c" font-size="19">observation Box(5): x, y, goal x,</text>
+<text x="548" y="470" fill="#9aa19c" font-size="19">goal y, steps remaining</text>
+<text x="548" y="504" fill="#9aa19c" font-size="19">action Discrete(5), edge clamped</text>
 
 <path d="M 482 448 L 518 448" stroke="#949a96" stroke-width="2" fill="none" marker-end="url(#a)"/>
 
-<text x="62" y="578" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">03</text>
-<text x="96" y="578" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">AGENT</text>
-<text x="200" y="578" fill="#757c77" font-size="18">PPOAgent, actor and critic on one trunk</text>
-<line x1="62" y1="592" x2="946" y2="592" stroke="#222c25" stroke-width="1"/>
+<text x="62" y="578" fill="#58916d" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">03</text>
+<text x="96" y="578" fill="#c4cac5" font-size="17" font-weight="700" letter-spacing="2.2">AGENT</text>
+<text x="200" y="578" fill="#6b726d" font-size="18">PPOAgent, actor and critic on one trunk</text>
+<line x1="62" y1="592" x2="946" y2="592" stroke="#1b221d" stroke-width="1"/>
 
-<rect x="62" y="608" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
+<rect x="62" y="608" width="420" height="152" fill="url(#panel)" stroke="#2e3830" stroke-width="1.5"/>
 <rect x="74" y="608.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="84" y="644" fill="#ecefed" font-size="22" font-weight="700">PPOPolicy</text>
-<text x="84" y="678" fill="#a5aca7" font-size="19">shared Linear(5, 64) + ReLU</text>
-<text x="84" y="706" fill="#a5aca7" font-size="19">policy head (5), value head (1)</text>
-<text x="84" y="740" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">sample training, argmax serving</text>
+<text x="84" y="678" fill="#9aa19c" font-size="19">shared Linear(5, 64) + ReLU</text>
+<text x="84" y="706" fill="#9aa19c" font-size="19">policy head (5), value head (1)</text>
+<text x="84" y="740" fill="#787f7a" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">sample training, argmax serving</text>
 
-<rect x="526" y="608" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
+<rect x="526" y="608" width="420" height="152" fill="url(#panel)" stroke="#2e3830" stroke-width="1.5"/>
 <rect x="538" y="608.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="548" y="644" fill="#ecefed" font-size="22" font-weight="700">clipped surrogate update</text>
-<text x="548" y="678" fill="#a5aca7" font-size="19">policy, value and entropy terms</text>
-<text x="548" y="712" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">eps_clip 0.2, gamma 0.99</text>
-<text x="548" y="740" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Adam lr 3e-4, 3 epochs</text>
+<text x="548" y="678" fill="#9aa19c" font-size="19">policy, value and entropy terms</text>
+<text x="548" y="712" fill="#787f7a" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">eps_clip 0.2, gamma 0.99</text>
+<text x="548" y="740" fill="#787f7a" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Adam lr 3e-4, 3 epochs</text>
 
 <path d="M 482 684 L 518 684" stroke="#949a96" stroke-width="2" fill="none" marker-end="url(#a)"/>
 
 <text x="62" y="814" fill="#e8ebe9" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">04</text>
 <text x="96" y="814" fill="#ffffff" font-size="17" font-weight="700" letter-spacing="2.2">VALIDATORS</text>
-<text x="262" y="814" fill="#aeb4af" font-size="18">every step answers both questions; the subject of this repository</text>
-<line x1="62" y1="828" x2="946" y2="828" stroke="#4a564d" stroke-width="1"/>
+<text x="262" y="814" fill="#a4aba6" font-size="18">every step answers both questions; the subject of this repository</text>
+<line x1="62" y1="828" x2="946" y2="828" stroke="#37423a" stroke-width="1"/>
 
 <rect x="62" y="844" width="420" height="146" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="84" y="882" fill="#ffffff" font-size="22" font-weight="700">IntegrityValidator</text>
-<text x="84" y="916" fill="#ccd2ce" font-size="19">observation inside its space?</text>
-<text x="84" y="944" fill="#ccd2ce" font-size="19">action legal? reward finite?</text>
-<text x="84" y="972" fill="#8f968f" font-size="17">on the environment side</text>
+<text x="84" y="916" fill="#c4cac5" font-size="19">observation inside its space?</text>
+<text x="84" y="944" fill="#c4cac5" font-size="19">action legal? reward finite?</text>
+<text x="84" y="972" fill="#838a85" font-size="17">on the environment side</text>
 
 <rect x="526" y="844" width="420" height="146" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="548" y="882" fill="#ffffff" font-size="22" font-weight="700">PolicyIntegrityValidator</text>
-<text x="548" y="916" fill="#ccd2ce" font-size="19">probabilities sum to 1?</text>
-<text x="548" y="944" fill="#ccd2ce" font-size="19">value finite? action in space?</text>
-<text x="548" y="972" fill="#8f968f" font-size="17">on the agent side</text>
+<text x="548" y="916" fill="#c4cac5" font-size="19">probabilities sum to 1?</text>
+<text x="548" y="944" fill="#c4cac5" font-size="19">value finite? action in space?</text>
+<text x="548" y="972" fill="#838a85" font-size="17">on the agent side</text>
 
 <path d="M 482 910 L 518 910" stroke="#e8ebe9" stroke-width="2.2" fill="none" marker-end="url(#ab)"/>
 
 <rect x="62" y="1010" width="884" height="86" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="84" y="1046" fill="#ffffff" font-size="22" font-weight="700">IntegrityStats</text>
-<text x="84" y="1078" fill="#ccd2ce" font-size="19">drift against hallucination, reported as a rate per step, never as a bare count</text>
+<text x="84" y="1078" fill="#c4cac5" font-size="19">drift against hallucination, reported as a rate per step, never as a bare count</text>
 
-<text x="62" y="1150" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">05</text>
-<text x="96" y="1150" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">SERVING</text>
-<text x="222" y="1150" fill="#757c77" font-size="18">validators report, but never halt a run</text>
-<line x1="62" y1="1164" x2="946" y2="1164" stroke="#222c25" stroke-width="1"/>
+<text x="62" y="1150" fill="#58916d" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">05</text>
+<text x="96" y="1150" fill="#c4cac5" font-size="17" font-weight="700" letter-spacing="2.2">SERVING</text>
+<text x="222" y="1150" fill="#6b726d" font-size="18">validators report, but never halt a run</text>
+<line x1="62" y1="1164" x2="946" y2="1164" stroke="#1b221d" stroke-width="1"/>
 
-<rect x="62" y="1180" width="420" height="34" fill="url(#panel)" stroke="#47514a" stroke-width="1.4"/>
-<text x="84" y="1203" fill="#a5aca7" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FastAPI /predict /metrics /healthz</text>
-<rect x="526" y="1180" width="420" height="34" fill="url(#panel)" stroke="#47514a" stroke-width="1.4"/>
-<text x="548" y="1203" fill="#a5aca7" font-size="18">Prometheus and Grafana scrape /metrics</text>
+<rect x="62" y="1180" width="420" height="34" fill="url(#panel)" stroke="#2e3830" stroke-width="1.4"/>
+<text x="84" y="1203" fill="#9aa19c" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FastAPI /predict /metrics /healthz</text>
+<rect x="526" y="1180" width="420" height="34" fill="url(#panel)" stroke="#2e3830" stroke-width="1.4"/>
+<text x="548" y="1203" fill="#9aa19c" font-size="18">Prometheus and Grafana scrape /metrics</text>
 </svg>

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 856" width="980" height="856" role="img" aria-label="Architecture: config feeds the DroneEnv, the PPO agent closes the loop, a validator band watches both sides, and the policy is served behind FastAPI" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 1200" width="980" height="1200" role="img" aria-label="Architecture: configs/env.yaml feeds the DroneEnv, the PPO agent closes the loop, a validator band watches both sides and reports into IntegrityStats, and the policy is served behind FastAPI" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0" stop-color="#12161d"/>
@@ -26,102 +26,88 @@
   </marker>
 </defs>
 
-<rect x="0" y="0" width="980" height="856" rx="12" fill="url(#bg)"/>
+<rect x="0" y="0" width="980" height="1200" rx="12" fill="url(#bg)"/>
 
-<text x="34" y="52" fill="#f2f6fa" font-size="27" font-weight="700" letter-spacing="0.2">Architecture</text>
-<text x="34" y="79" fill="#93a1b3" font-size="15.5">One control loop, top to bottom. The bright band is the part that watches.</text>
-<text x="946" y="52" fill="#8f9dae" font-size="14.5" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
-<text x="946" y="76" fill="#8f9dae" font-size="14.5" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
+<text x="34" y="58" fill="#f2f6fa" font-size="32" font-weight="700">Architecture</text>
+<text x="34" y="90" fill="#93a1b3" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
+<text x="946" y="58" fill="#8f9dae" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
+<text x="946" y="86" fill="#8f9dae" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
 
-<line x1="34" y1="100" x2="946" y2="100" stroke="#2b333f" stroke-width="1"/>
+<line x1="34" y1="116" x2="946" y2="116" stroke="#2b333f" stroke-width="1"/>
 
-<text x="34" y="132" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6">CONFIG</text>
-<text x="150" y="132" fill="#6f7c8d" font-size="15">the only file the code actually reads</text>
-<rect x="34" y="146" width="330" height="72" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="52" y="174" fill="#e9eff6" font-size="18" font-weight="700">configs/env.yaml</text>
-<text x="52" y="199" fill="#9dabbc" font-size="15.5">grid_size 20, max_steps 200</text>
+<text x="34" y="154" fill="#7e8b9c" font-size="17" font-weight="700" letter-spacing="1.8">CONFIG</text>
+<text x="170" y="154" fill="#6f7c8d" font-size="18">the only file the code actually reads</text>
+<rect x="34" y="172" width="440" height="88" rx="9" fill="url(#panel)" stroke="#46515f" stroke-width="1.8"/>
+<text x="56" y="208" fill="#e9eff6" font-size="22" font-weight="700">configs/env.yaml</text>
+<text x="56" y="240" fill="#9dabbc" font-size="19">grid_size 20, max_steps 200</text>
 
-<line x1="34" y1="244" x2="946" y2="244" stroke="#2b333f" stroke-width="1"/>
+<line x1="34" y1="292" x2="946" y2="292" stroke="#2b333f" stroke-width="1"/>
 
-<text x="34" y="276" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6">ENVIRONMENT</text>
-<text x="185" y="276" fill="#6f7c8d" font-size="15">DroneEnv, a gymnasium grid world</text>
-<rect x="34" y="290" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="52" y="318" fill="#e9eff6" font-size="18" font-weight="700">reset() and step(action)</text>
-<text x="52" y="342" fill="#9dabbc" font-size="15.5">returns obs, reward,</text>
-<text x="52" y="364" fill="#9dabbc" font-size="15.5">terminated, truncated, info</text>
+<text x="34" y="330" fill="#7e8b9c" font-size="17" font-weight="700" letter-spacing="1.8">ENVIRONMENT</text>
+<text x="220" y="330" fill="#6f7c8d" font-size="18">DroneEnv, a gymnasium grid world</text>
 
-<rect x="347" y="290" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="365" y="318" fill="#e9eff6" font-size="18" font-weight="700">observation, Box(5)</text>
-<text x="365" y="342" fill="#9dabbc" font-size="15.5">x, y, goal x, goal y,</text>
-<text x="365" y="364" fill="#9dabbc" font-size="15.5">steps remaining</text>
+<rect x="34" y="348" width="440" height="152" rx="9" fill="url(#panel)" stroke="#46515f" stroke-width="1.8"/>
+<text x="56" y="384" fill="#e9eff6" font-size="22" font-weight="700">reset() and step(action)</text>
+<text x="56" y="418" fill="#9dabbc" font-size="19">returns obs, reward, terminated,</text>
+<text x="56" y="446" fill="#9dabbc" font-size="19">truncated, info</text>
+<text x="56" y="480" fill="#8f9dae" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+10 at goal, -1 per step</text>
 
-<rect x="660" y="290" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="678" y="318" fill="#e9eff6" font-size="18" font-weight="700">action, Discrete(5)</text>
-<text x="678" y="342" fill="#9dabbc" font-size="15.5">hover, up, down, left, right</text>
-<text x="678" y="364" fill="#9dabbc" font-size="15.5">clamped at the grid edge</text>
+<rect x="506" y="348" width="440" height="152" rx="9" fill="url(#panel)" stroke="#46515f" stroke-width="1.8"/>
+<text x="528" y="384" fill="#e9eff6" font-size="22" font-weight="700">spaces</text>
+<text x="528" y="418" fill="#9dabbc" font-size="19">observation Box(5): x, y, goal x,</text>
+<text x="528" y="446" fill="#9dabbc" font-size="19">goal y, steps remaining</text>
+<text x="528" y="480" fill="#9dabbc" font-size="19">action Discrete(5), edge clamped</text>
 
-<line x1="34" y1="402" x2="946" y2="402" stroke="#2b333f" stroke-width="1"/>
+<path d="M 474 424 L 500 424" stroke="#aab6c6" stroke-width="2" fill="none" marker-end="url(#a)"/>
 
-<text x="34" y="434" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6">AGENT</text>
-<text x="130" y="434" fill="#6f7c8d" font-size="15">PPOAgent, actor and critic on one trunk</text>
-<rect x="34" y="448" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="52" y="476" fill="#e9eff6" font-size="18" font-weight="700">PPOPolicy</text>
-<text x="52" y="500" fill="#9dabbc" font-size="15.5">shared Linear(5, 64) + ReLU</text>
-<text x="52" y="522" fill="#9dabbc" font-size="15.5">policy head (5), value head (1)</text>
+<line x1="34" y1="532" x2="946" y2="532" stroke="#2b333f" stroke-width="1"/>
 
-<rect x="347" y="448" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="365" y="476" fill="#e9eff6" font-size="18" font-weight="700">clipped surrogate update</text>
-<text x="365" y="500" fill="#9dabbc" font-size="15.5">eps_clip 0.2, gamma 0.99</text>
-<text x="365" y="522" fill="#9dabbc" font-size="15.5">Adam lr 3e-4, 3 epochs</text>
+<text x="34" y="570" fill="#7e8b9c" font-size="17" font-weight="700" letter-spacing="1.8">AGENT</text>
+<text x="150" y="570" fill="#6f7c8d" font-size="18">PPOAgent, actor and critic on one trunk</text>
 
-<rect x="660" y="448" width="286" height="86" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="678" y="476" fill="#e9eff6" font-size="18" font-weight="700">select_action / predict</text>
-<text x="678" y="500" fill="#9dabbc" font-size="15.5">sample while training,</text>
-<text x="678" y="522" fill="#9dabbc" font-size="15.5">argmax at inference</text>
+<rect x="34" y="588" width="440" height="152" rx="9" fill="url(#panel)" stroke="#46515f" stroke-width="1.8"/>
+<text x="56" y="624" fill="#e9eff6" font-size="22" font-weight="700">PPOPolicy</text>
+<text x="56" y="658" fill="#9dabbc" font-size="19">shared Linear(5, 64) + ReLU</text>
+<text x="56" y="686" fill="#9dabbc" font-size="19">policy head (5), value head (1)</text>
+<text x="56" y="720" fill="#8f9dae" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">sample training, argmax serving</text>
 
-<path d="M 320 333 L 341 333" stroke="#aab6c6" stroke-width="1.8" fill="none" marker-end="url(#a)"/>
-<path d="M 633 333 L 654 333" stroke="#aab6c6" stroke-width="1.8" fill="none" marker-end="url(#a)"/>
-<path d="M 320 491 L 341 491" stroke="#aab6c6" stroke-width="1.8" fill="none" marker-end="url(#a)"/>
-<path d="M 633 491 L 654 491" stroke="#aab6c6" stroke-width="1.8" fill="none" marker-end="url(#a)"/>
+<rect x="506" y="588" width="440" height="152" rx="9" fill="url(#panel)" stroke="#46515f" stroke-width="1.8"/>
+<text x="528" y="624" fill="#e9eff6" font-size="22" font-weight="700">clipped surrogate update</text>
+<text x="528" y="658" fill="#9dabbc" font-size="19">policy, value and entropy terms</text>
+<text x="528" y="692" fill="#8f9dae" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">eps_clip 0.2, gamma 0.99</text>
+<text x="528" y="720" fill="#8f9dae" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Adam lr 3e-4, 3 epochs</text>
 
+<path d="M 474 664 L 500 664" stroke="#aab6c6" stroke-width="2" fill="none" marker-end="url(#a)"/>
 
-<line x1="34" y1="560" x2="946" y2="560" stroke="#2b333f" stroke-width="1"/>
+<line x1="34" y1="772" x2="946" y2="772" stroke="#2b333f" stroke-width="1"/>
 
-<text x="34" y="592" fill="#e6edf5" font-size="14" font-weight="700" letter-spacing="1.6">VALIDATORS</text>
-<text x="168" y="592" fill="#aab6c6" font-size="15">every step answers both questions; this is the subject of the repository</text>
-<rect x="34" y="606" width="286" height="96" rx="8" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.4"/>
-<text x="52" y="634" fill="#ffffff" font-size="18" font-weight="700">IntegrityValidator</text>
-<text x="52" y="658" fill="#c3cedd" font-size="15.5">observation inside its space?</text>
-<text x="52" y="680" fill="#c3cedd" font-size="15.5">action legal? reward finite?</text>
+<text x="34" y="810" fill="#e6edf5" font-size="17" font-weight="700" letter-spacing="1.8">VALIDATORS</text>
+<text x="200" y="810" fill="#aab6c6" font-size="18">every step answers both questions; the subject of this repository</text>
 
-<rect x="347" y="606" width="286" height="96" rx="8" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.4"/>
-<text x="365" y="634" fill="#ffffff" font-size="18" font-weight="700">PolicyIntegrityValidator</text>
-<text x="365" y="658" fill="#c3cedd" font-size="15.5">probabilities sum to 1?</text>
-<text x="365" y="680" fill="#c3cedd" font-size="15.5">value finite? action in space?</text>
+<rect x="34" y="828" width="440" height="140" rx="9" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.6"/>
+<text x="56" y="864" fill="#ffffff" font-size="22" font-weight="700">IntegrityValidator</text>
+<text x="56" y="898" fill="#c3cedd" font-size="19">observation inside its space?</text>
+<text x="56" y="926" fill="#c3cedd" font-size="19">action legal? reward finite?</text>
+<text x="56" y="952" fill="#8f9dae" font-size="17">on the environment side</text>
 
-<rect x="660" y="606" width="286" height="96" rx="8" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.4"/>
-<text x="678" y="634" fill="#ffffff" font-size="18" font-weight="700">IntegrityStats</text>
-<text x="678" y="658" fill="#c3cedd" font-size="15.5">drift against hallucination,</text>
-<text x="678" y="680" fill="#c3cedd" font-size="15.5">as a rate per step</text>
+<rect x="506" y="828" width="440" height="140" rx="9" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.6"/>
+<text x="528" y="864" fill="#ffffff" font-size="22" font-weight="700">PolicyIntegrityValidator</text>
+<text x="528" y="898" fill="#c3cedd" font-size="19">probabilities sum to 1?</text>
+<text x="528" y="926" fill="#c3cedd" font-size="19">value finite? action in space?</text>
+<text x="528" y="952" fill="#8f9dae" font-size="17">on the agent side</text>
 
-<path d="M 320 654 L 341 654" stroke="#e6edf5" stroke-width="2" fill="none" marker-end="url(#ab)"/>
-<path d="M 633 654 L 654 654" stroke="#e6edf5" stroke-width="2" fill="none" marker-end="url(#ab)"/>
+<path d="M 474 890 L 500 890" stroke="#e6edf5" stroke-width="2.2" fill="none" marker-end="url(#ab)"/>
 
-<line x1="34" y1="728" x2="946" y2="728" stroke="#2b333f" stroke-width="1"/>
+<rect x="34" y="988" width="912" height="88" rx="9" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.6"/>
+<text x="56" y="1024" fill="#ffffff" font-size="22" font-weight="700">IntegrityStats</text>
+<text x="56" y="1056" fill="#c3cedd" font-size="19">drift against hallucination, reported as a rate per step, never as a bare count</text>
 
-<text x="34" y="760" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6">SERVING</text>
-<text x="152" y="760" fill="#6f7c8d" font-size="15">weights load once at startup; validators report but never halt a run</text>
-<rect x="34" y="774" width="286" height="62" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="52" y="800" fill="#e9eff6" font-size="18" font-weight="700">FastAPI</text>
-<text x="52" y="824" fill="#9dabbc" font-size="14.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">/predict /metrics /healthz</text>
+<line x1="34" y1="1108" x2="946" y2="1108" stroke="#2b333f" stroke-width="1"/>
 
-<rect x="347" y="774" width="286" height="62" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="365" y="800" fill="#e9eff6" font-size="18" font-weight="700">Prometheus + Grafana</text>
-<text x="365" y="824" fill="#9dabbc" font-size="15.5">scrapes /metrics</text>
-
-<rect x="660" y="774" width="286" height="62" rx="8" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
-<text x="678" y="800" fill="#e9eff6" font-size="18" font-weight="700">models/ppo_drone.pt</text>
-<text x="678" y="824" fill="#9dabbc" font-size="15.5">loaded at startup</text>
-
-<path d="M 320 805 L 341 805" stroke="#aab6c6" stroke-width="1.8" fill="none" marker-end="url(#a)"/>
+<text x="34" y="1146" fill="#7e8b9c" font-size="17" font-weight="700" letter-spacing="1.8">SERVING</text>
+<text x="168" y="1146" fill="#6f7c8d" font-size="18">validators report, but never halt a run</text>
+<rect x="34" y="1160" width="440" height="26" rx="6" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="56" y="1179" fill="#9dabbc" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FastAPI /predict /metrics /healthz</text>
+<rect x="506" y="1160" width="440" height="26" rx="6" fill="url(#panel)" stroke="#46515f" stroke-width="1.6"/>
+<text x="528" y="1179" fill="#9dabbc" font-size="17">Prometheus and Grafana scrape /metrics</text>
 </svg>

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,142 +1,142 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 1240" width="980" height="1240" role="img" aria-label="System map: configs/env.yaml feeds the DroneEnv, the PPO agent closes the loop, a validator band watches both sides and reports into IntegrityStats, and the policy is served behind FastAPI" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0.4" y2="1">
-    <stop offset="0" stop-color="#0d131b"/>
-    <stop offset="0.55" stop-color="#080c12"/>
-    <stop offset="1" stop-color="#05080c"/>
+    <stop offset="0" stop-color="#0b120e"/>
+    <stop offset="0.55" stop-color="#070b08"/>
+    <stop offset="1" stop-color="#050805"/>
   </linearGradient>
   <pattern id="grid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#131b25"/>
+    <circle cx="1" cy="1" r="0.7" fill="#121a14"/>
   </pattern>
   <linearGradient id="chrome" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#5d6b7d"/>
-    <stop offset="0.28" stop-color="#eaf2fa"/>
-    <stop offset="0.5" stop-color="#93a2b4"/>
-    <stop offset="0.72" stop-color="#f2f8ff"/>
-    <stop offset="1" stop-color="#66748a"/>
+    <stop offset="0" stop-color="#6d716f"/>
+    <stop offset="0.28" stop-color="#e8ebe9"/>
+    <stop offset="0.5" stop-color="#9ba09d"/>
+    <stop offset="0.72" stop-color="#fafbfa"/>
+    <stop offset="1" stop-color="#767b78"/>
   </linearGradient>
   <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#1b2431"/>
-    <stop offset="0.5" stop-color="#151d28"/>
-    <stop offset="1" stop-color="#111820"/>
+    <stop offset="0" stop-color="#172018"/>
+    <stop offset="0.5" stop-color="#131a14"/>
+    <stop offset="1" stop-color="#0f1510"/>
   </linearGradient>
   <linearGradient id="panelLive" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#26323f"/>
-    <stop offset="1" stop-color="#161e28"/>
+    <stop offset="0" stop-color="#202c23"/>
+    <stop offset="1" stop-color="#141c16"/>
   </linearGradient>
   <linearGradient id="edge" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#3d4d61" stop-opacity="0.2"/>
-    <stop offset="0.5" stop-color="#8fa3ba" stop-opacity="0.75"/>
-    <stop offset="1" stop-color="#3d4d61" stop-opacity="0.2"/>
+    <stop offset="0" stop-color="#454f47" stop-opacity="0.2"/>
+    <stop offset="0.5" stop-color="#949a96" stop-opacity="0.75"/>
+    <stop offset="1" stop-color="#454f47" stop-opacity="0.2"/>
   </linearGradient>
   <linearGradient id="spine" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#8ab0cf" stop-opacity="0"/>
-    <stop offset="0.12" stop-color="#8ab0cf" stop-opacity="0.55"/>
-    <stop offset="0.88" stop-color="#8ab0cf" stop-opacity="0.55"/>
-    <stop offset="1" stop-color="#8ab0cf" stop-opacity="0"/>
+    <stop offset="0" stop-color="#6faa85" stop-opacity="0"/>
+    <stop offset="0.12" stop-color="#6faa85" stop-opacity="0.55"/>
+    <stop offset="0.88" stop-color="#6faa85" stop-opacity="0.55"/>
+    <stop offset="1" stop-color="#6faa85" stop-opacity="0"/>
   </linearGradient>
   <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
-    <path d="M0,0 L10,5 L0,10 z" fill="#8fa3ba"/>
+    <path d="M0,0 L10,5 L0,10 z" fill="#949a96"/>
   </marker>
   <marker id="ab" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
-    <path d="M0,0 L10,5 L0,10 z" fill="#eaf2fa"/>
+    <path d="M0,0 L10,5 L0,10 z" fill="#e8ebe9"/>
   </marker>
 </defs>
 
 <rect x="0" y="0" width="980" height="1240" fill="url(#bg)"/>
 <rect x="0" y="0" width="980" height="1240" fill="url(#grid)"/>
 
-<rect x="34" y="150" width="1" height="1010" fill="#243040"/>
+<rect x="34" y="150" width="1" height="1010" fill="#232d26"/>
 
-<text x="34" y="46" fill="#8ab0cf" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SYSTEM MAP</text>
-<text x="34" y="88" fill="#f4f8fc" font-size="34" font-weight="700" letter-spacing="0.4">Architecture</text>
-<text x="34" y="118" fill="#8ea0b5" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
-<rect x="700" y="30" width="2" height="62" fill="#2b3949"/>
-<text x="946" y="52" fill="#93a6bb" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
-<text x="946" y="78" fill="#93a6bb" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
+<text x="34" y="46" fill="#6faa85" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SYSTEM MAP</text>
+<text x="34" y="88" fill="#f2f5f3" font-size="34" font-weight="700" letter-spacing="0.4">Architecture</text>
+<text x="34" y="118" fill="#939a95" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
+<rect x="700" y="30" width="2" height="62" fill="#333d36"/>
+<text x="946" y="52" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
+<text x="946" y="78" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
 
-<text x="62" y="170" fill="#8ab0cf" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
-<text x="96" y="170" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">CONFIG</text>
-<text x="216" y="170" fill="#6d7d90" font-size="18">the only file the code actually reads</text>
-<line x1="62" y1="184" x2="946" y2="184" stroke="#1e2a37" stroke-width="1"/>
+<text x="62" y="170" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
+<text x="96" y="170" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">CONFIG</text>
+<text x="216" y="170" fill="#757c77" font-size="18">the only file the code actually reads</text>
+<line x1="62" y1="184" x2="946" y2="184" stroke="#222c25" stroke-width="1"/>
 
-<rect x="62" y="200" width="440" height="88" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="62" y="200" width="440" height="88" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="74" y="200.7" width="416" height="1.4" fill="url(#edge)"/>
-<text x="84" y="236" fill="#eef4fa" font-size="22" font-weight="700">configs/env.yaml</text>
-<text x="84" y="268" fill="#9fb0c3" font-size="19" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid_size 20, max_steps 200</text>
+<text x="84" y="236" fill="#ecefed" font-size="22" font-weight="700">configs/env.yaml</text>
+<text x="84" y="268" fill="#a5aca7" font-size="19" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid_size 20, max_steps 200</text>
 
-<text x="62" y="342" fill="#8ab0cf" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">02</text>
-<text x="96" y="342" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">ENVIRONMENT</text>
-<text x="280" y="342" fill="#6d7d90" font-size="18">DroneEnv, a gymnasium grid world</text>
-<line x1="62" y1="356" x2="946" y2="356" stroke="#1e2a37" stroke-width="1"/>
+<text x="62" y="342" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">02</text>
+<text x="96" y="342" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">ENVIRONMENT</text>
+<text x="280" y="342" fill="#757c77" font-size="18">DroneEnv, a gymnasium grid world</text>
+<line x1="62" y1="356" x2="946" y2="356" stroke="#222c25" stroke-width="1"/>
 
-<rect x="62" y="372" width="420" height="152" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="62" y="372" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="74" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
-<text x="84" y="408" fill="#eef4fa" font-size="22" font-weight="700">reset() and step(action)</text>
-<text x="84" y="442" fill="#9fb0c3" font-size="19">returns obs, reward, terminated,</text>
-<text x="84" y="470" fill="#9fb0c3" font-size="19">truncated, info</text>
-<text x="84" y="504" fill="#7f92a8" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+10 at goal, -1 per step</text>
+<text x="84" y="408" fill="#ecefed" font-size="22" font-weight="700">reset() and step(action)</text>
+<text x="84" y="442" fill="#a5aca7" font-size="19">returns obs, reward, terminated,</text>
+<text x="84" y="470" fill="#a5aca7" font-size="19">truncated, info</text>
+<text x="84" y="504" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+10 at goal, -1 per step</text>
 
-<rect x="526" y="372" width="420" height="152" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="526" y="372" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="538" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
-<text x="548" y="408" fill="#eef4fa" font-size="22" font-weight="700">spaces</text>
-<text x="548" y="442" fill="#9fb0c3" font-size="19">observation Box(5): x, y, goal x,</text>
-<text x="548" y="470" fill="#9fb0c3" font-size="19">goal y, steps remaining</text>
-<text x="548" y="504" fill="#9fb0c3" font-size="19">action Discrete(5), edge clamped</text>
+<text x="548" y="408" fill="#ecefed" font-size="22" font-weight="700">spaces</text>
+<text x="548" y="442" fill="#a5aca7" font-size="19">observation Box(5): x, y, goal x,</text>
+<text x="548" y="470" fill="#a5aca7" font-size="19">goal y, steps remaining</text>
+<text x="548" y="504" fill="#a5aca7" font-size="19">action Discrete(5), edge clamped</text>
 
-<path d="M 482 448 L 518 448" stroke="#8fa3ba" stroke-width="2" fill="none" marker-end="url(#a)"/>
+<path d="M 482 448 L 518 448" stroke="#949a96" stroke-width="2" fill="none" marker-end="url(#a)"/>
 
-<text x="62" y="578" fill="#8ab0cf" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">03</text>
-<text x="96" y="578" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">AGENT</text>
-<text x="200" y="578" fill="#6d7d90" font-size="18">PPOAgent, actor and critic on one trunk</text>
-<line x1="62" y1="592" x2="946" y2="592" stroke="#1e2a37" stroke-width="1"/>
+<text x="62" y="578" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">03</text>
+<text x="96" y="578" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">AGENT</text>
+<text x="200" y="578" fill="#757c77" font-size="18">PPOAgent, actor and critic on one trunk</text>
+<line x1="62" y1="592" x2="946" y2="592" stroke="#222c25" stroke-width="1"/>
 
-<rect x="62" y="608" width="420" height="152" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="62" y="608" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="74" y="608.7" width="396" height="1.4" fill="url(#edge)"/>
-<text x="84" y="644" fill="#eef4fa" font-size="22" font-weight="700">PPOPolicy</text>
-<text x="84" y="678" fill="#9fb0c3" font-size="19">shared Linear(5, 64) + ReLU</text>
-<text x="84" y="706" fill="#9fb0c3" font-size="19">policy head (5), value head (1)</text>
-<text x="84" y="740" fill="#7f92a8" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">sample training, argmax serving</text>
+<text x="84" y="644" fill="#ecefed" font-size="22" font-weight="700">PPOPolicy</text>
+<text x="84" y="678" fill="#a5aca7" font-size="19">shared Linear(5, 64) + ReLU</text>
+<text x="84" y="706" fill="#a5aca7" font-size="19">policy head (5), value head (1)</text>
+<text x="84" y="740" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">sample training, argmax serving</text>
 
-<rect x="526" y="608" width="420" height="152" fill="url(#panel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="526" y="608" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="538" y="608.7" width="396" height="1.4" fill="url(#edge)"/>
-<text x="548" y="644" fill="#eef4fa" font-size="22" font-weight="700">clipped surrogate update</text>
-<text x="548" y="678" fill="#9fb0c3" font-size="19">policy, value and entropy terms</text>
-<text x="548" y="712" fill="#7f92a8" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">eps_clip 0.2, gamma 0.99</text>
-<text x="548" y="740" fill="#7f92a8" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Adam lr 3e-4, 3 epochs</text>
+<text x="548" y="644" fill="#ecefed" font-size="22" font-weight="700">clipped surrogate update</text>
+<text x="548" y="678" fill="#a5aca7" font-size="19">policy, value and entropy terms</text>
+<text x="548" y="712" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">eps_clip 0.2, gamma 0.99</text>
+<text x="548" y="740" fill="#838a85" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Adam lr 3e-4, 3 epochs</text>
 
-<path d="M 482 684 L 518 684" stroke="#8fa3ba" stroke-width="2" fill="none" marker-end="url(#a)"/>
+<path d="M 482 684 L 518 684" stroke="#949a96" stroke-width="2" fill="none" marker-end="url(#a)"/>
 
-<text x="62" y="814" fill="#eaf2fa" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">04</text>
+<text x="62" y="814" fill="#e8ebe9" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">04</text>
 <text x="96" y="814" fill="#ffffff" font-size="17" font-weight="700" letter-spacing="2.2">VALIDATORS</text>
-<text x="262" y="814" fill="#a9bbcd" font-size="18">every step answers both questions; the subject of this repository</text>
-<line x1="62" y1="828" x2="946" y2="828" stroke="#42566b" stroke-width="1"/>
+<text x="262" y="814" fill="#aeb4af" font-size="18">every step answers both questions; the subject of this repository</text>
+<line x1="62" y1="828" x2="946" y2="828" stroke="#4a564d" stroke-width="1"/>
 
 <rect x="62" y="844" width="420" height="146" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="84" y="882" fill="#ffffff" font-size="22" font-weight="700">IntegrityValidator</text>
-<text x="84" y="916" fill="#ccd9e7" font-size="19">observation inside its space?</text>
-<text x="84" y="944" fill="#ccd9e7" font-size="19">action legal? reward finite?</text>
-<text x="84" y="972" fill="#8ba0b6" font-size="17">on the environment side</text>
+<text x="84" y="916" fill="#ccd2ce" font-size="19">observation inside its space?</text>
+<text x="84" y="944" fill="#ccd2ce" font-size="19">action legal? reward finite?</text>
+<text x="84" y="972" fill="#8f968f" font-size="17">on the environment side</text>
 
 <rect x="526" y="844" width="420" height="146" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="548" y="882" fill="#ffffff" font-size="22" font-weight="700">PolicyIntegrityValidator</text>
-<text x="548" y="916" fill="#ccd9e7" font-size="19">probabilities sum to 1?</text>
-<text x="548" y="944" fill="#ccd9e7" font-size="19">value finite? action in space?</text>
-<text x="548" y="972" fill="#8ba0b6" font-size="17">on the agent side</text>
+<text x="548" y="916" fill="#ccd2ce" font-size="19">probabilities sum to 1?</text>
+<text x="548" y="944" fill="#ccd2ce" font-size="19">value finite? action in space?</text>
+<text x="548" y="972" fill="#8f968f" font-size="17">on the agent side</text>
 
-<path d="M 482 910 L 518 910" stroke="#eaf2fa" stroke-width="2.2" fill="none" marker-end="url(#ab)"/>
+<path d="M 482 910 L 518 910" stroke="#e8ebe9" stroke-width="2.2" fill="none" marker-end="url(#ab)"/>
 
 <rect x="62" y="1010" width="884" height="86" fill="url(#panelLive)" stroke="url(#chrome)" stroke-width="2.2"/>
 <text x="84" y="1046" fill="#ffffff" font-size="22" font-weight="700">IntegrityStats</text>
-<text x="84" y="1078" fill="#ccd9e7" font-size="19">drift against hallucination, reported as a rate per step, never as a bare count</text>
+<text x="84" y="1078" fill="#ccd2ce" font-size="19">drift against hallucination, reported as a rate per step, never as a bare count</text>
 
-<text x="62" y="1150" fill="#8ab0cf" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">05</text>
-<text x="96" y="1150" fill="#c6d3e2" font-size="17" font-weight="700" letter-spacing="2.2">SERVING</text>
-<text x="222" y="1150" fill="#6d7d90" font-size="18">validators report, but never halt a run</text>
-<line x1="62" y1="1164" x2="946" y2="1164" stroke="#1e2a37" stroke-width="1"/>
+<text x="62" y="1150" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">05</text>
+<text x="96" y="1150" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">SERVING</text>
+<text x="222" y="1150" fill="#757c77" font-size="18">validators report, but never halt a run</text>
+<line x1="62" y1="1164" x2="946" y2="1164" stroke="#222c25" stroke-width="1"/>
 
-<rect x="62" y="1180" width="420" height="34" fill="url(#panel)" stroke="#3a4859" stroke-width="1.4"/>
-<text x="84" y="1203" fill="#9fb0c3" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FastAPI /predict /metrics /healthz</text>
-<rect x="526" y="1180" width="420" height="34" fill="url(#panel)" stroke="#3a4859" stroke-width="1.4"/>
-<text x="548" y="1203" fill="#9fb0c3" font-size="18">Prometheus and Grafana scrape /metrics</text>
+<rect x="62" y="1180" width="420" height="34" fill="url(#panel)" stroke="#47514a" stroke-width="1.4"/>
+<text x="84" y="1203" fill="#a5aca7" font-size="17" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FastAPI /predict /metrics /healthz</text>
+<rect x="526" y="1180" width="420" height="34" fill="url(#panel)" stroke="#47514a" stroke-width="1.4"/>
+<text x="548" y="1203" fill="#a5aca7" font-size="18">Prometheus and Grafana scrape /metrics</text>
 </svg>

--- a/assets/drift-vs-hallucination.svg
+++ b/assets/drift-vs-hallucination.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 470" width="980" height="470" role="img" aria-label="Drift against hallucination. Drift is a value of the right kind landing outside its declared range, shown as 200 sitting far beyond a bound of 20. Hallucination is a value that was never in the space at all, shown as action 999 detached from a five slot discrete space." font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="dbg" x1="0" y1="0" x2="0.5" y2="1">
+    <stop offset="0" stop-color="#0d131b"/>
+    <stop offset="1" stop-color="#05080c"/>
+  </linearGradient>
+  <pattern id="dgrid" width="26" height="26" patternUnits="userSpaceOnUse">
+    <circle cx="1" cy="1" r="0.7" fill="#16202c"/>
+  </pattern>
+  <linearGradient id="dpanel" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#1b2431"/>
+    <stop offset="1" stop-color="#111820"/>
+  </linearGradient>
+  <linearGradient id="band" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#7fd4ff" stop-opacity="0.16"/>
+    <stop offset="1" stop-color="#7fd4ff" stop-opacity="0.05"/>
+  </linearGradient>
+  <linearGradient id="dchrome" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#5d6b7d"/>
+    <stop offset="0.3" stop-color="#eaf2fa"/>
+    <stop offset="0.6" stop-color="#93a2b4"/>
+    <stop offset="1" stop-color="#66748a"/>
+  </linearGradient>
+</defs>
+
+<rect x="0" y="0" width="980" height="470" rx="14" fill="url(#dbg)"/>
+<rect x="0" y="0" width="980" height="470" rx="14" fill="url(#dgrid)"/>
+
+<text x="34" y="46" fill="#7fd4ff" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">TWO FAILURES, TWO RESPONSES</text>
+<text x="34" y="84" fill="#f4f8fc" font-size="30" font-weight="700">Drift is not hallucination</text>
+
+<rect x="34" y="110" width="440" height="252" rx="6" fill="url(#dpanel)" stroke="#3a4859" stroke-width="1.5"/>
+<text x="58" y="150" fill="#eef4fa" font-size="22" font-weight="700">DRIFT</text>
+<text x="132" y="150" fill="#8ea0b5" font-size="18">a bound was crossed</text>
+
+<rect x="58" y="196" width="216" height="36" rx="4" fill="url(#band)" stroke="#7fd4ff" stroke-width="1.2" stroke-dasharray="4 3"/>
+<line x1="58" y1="252" x2="450" y2="252" stroke="#3a4859" stroke-width="1.6"/>
+<line x1="58" y1="246" x2="58" y2="258" stroke="#8fa3ba" stroke-width="1.6"/>
+<line x1="274" y1="246" x2="274" y2="258" stroke="#8fa3ba" stroke-width="1.6"/>
+<text x="58" y="278" fill="#8ea0b5" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
+<text x="274" y="278" fill="#8ea0b5" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">20</text>
+<text x="166" y="220" fill="#9fb0c3" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">declared range</text>
+
+<circle cx="150" cy="252" r="6" fill="#8fa3ba"/>
+<circle cx="424" cy="252" r="8" fill="#eaf2fa"/>
+<text x="424" y="230" fill="#ffffff" font-size="17" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">200</text>
+
+<text x="58" y="316" fill="#ccd9e7" font-size="18">The right kind of value, in the wrong place.</text>
+<text x="58" y="342" fill="#8ea0b5" font-size="17">Widen the bound, retrain, or investigate.</text>
+
+<rect x="506" y="110" width="440" height="252" rx="6" fill="url(#dpanel)" stroke="url(#dchrome)" stroke-width="2"/>
+<text x="530" y="150" fill="#ffffff" font-size="22" font-weight="700">HALLUCINATION</text>
+<text x="746" y="150" fill="#a9bbcd" font-size="18">a value was invented</text>
+
+<g>
+  <rect x="530" y="204" width="46" height="46" rx="5" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
+  <text x="553" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
+  <rect x="584" y="204" width="46" height="46" rx="5" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
+  <text x="607" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">1</text>
+  <rect x="638" y="204" width="46" height="46" rx="5" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
+  <text x="661" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">2</text>
+  <rect x="692" y="204" width="46" height="46" rx="5" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
+  <text x="715" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">3</text>
+  <rect x="746" y="204" width="46" height="46" rx="5" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
+  <text x="769" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">4</text>
+</g>
+<text x="530" y="278" fill="#8ea0b5" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Discrete(5), the whole space</text>
+
+<line x1="812" y1="196" x2="812" y2="258" stroke="#42566b" stroke-width="1.4" stroke-dasharray="5 4"/>
+<rect x="838" y="204" width="82" height="46" rx="5" fill="#26323f" stroke="#eaf2fa" stroke-width="2"/>
+<text x="879" y="234" fill="#ffffff" font-size="18" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">999</text>
+
+<text x="530" y="316" fill="#ccd9e7" font-size="18">Never a member of the space at all.</text>
+<text x="530" y="342" fill="#a9bbcd" font-size="17">Stop. Do not widen anything to admit it.</text>
+
+<line x1="34" y1="396" x2="946" y2="396" stroke="#1e2a37" stroke-width="1"/>
+<text x="34" y="430" fill="#8ea0b5" font-size="17">The left panel is a real bug from this repository: <tspan fill="#eaf2fa" font-weight="700">steps_remaining</tspan> counts down from 200 while the</text>
+<text x="34" y="454" fill="#8ea0b5" font-size="17">declared bound was 20, so every step of every episode reported drift, correctly, and nobody read it.</text>
+</svg>

--- a/assets/drift-vs-hallucination.svg
+++ b/assets/drift-vs-hallucination.svg
@@ -1,79 +1,79 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 470" width="980" height="470" role="img" aria-label="Drift against hallucination. Drift is a value of the right kind landing outside its declared range, shown as 200 sitting far beyond a bound of 20. Hallucination is a value that was never in the space at all, shown as action 999 detached from a five slot discrete space." font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
   <linearGradient id="dbg" x1="0" y1="0" x2="0.5" y2="1">
-    <stop offset="0" stop-color="#0b120e"/>
-    <stop offset="1" stop-color="#050805"/>
+    <stop offset="0" stop-color="#060a07"/>
+    <stop offset="1" stop-color="#030503"/>
   </linearGradient>
   <pattern id="dgrid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#121a14"/>
+    <circle cx="1" cy="1" r="0.7" fill="#0d130f"/>
   </pattern>
   <linearGradient id="dpanel" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#172018"/>
-    <stop offset="1" stop-color="#0f1510"/>
+    <stop offset="0" stop-color="#10160f"/>
+    <stop offset="1" stop-color="#0b0f0c"/>
   </linearGradient>
   <linearGradient id="band" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#6faa85" stop-opacity="0.16"/>
-    <stop offset="1" stop-color="#6faa85" stop-opacity="0.05"/>
+    <stop offset="0" stop-color="#58916d" stop-opacity="0.16"/>
+    <stop offset="1" stop-color="#58916d" stop-opacity="0.05"/>
   </linearGradient>
   <linearGradient id="dchrome" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#6d716f"/>
+    <stop offset="0" stop-color="#5a5f5c"/>
     <stop offset="0.3" stop-color="#e8ebe9"/>
-    <stop offset="0.6" stop-color="#9ba09d"/>
-    <stop offset="1" stop-color="#767b78"/>
+    <stop offset="0.6" stop-color="#888d8a"/>
+    <stop offset="1" stop-color="#626764"/>
   </linearGradient>
 </defs>
 
 <rect x="0" y="0" width="980" height="470" fill="url(#dbg)"/>
 <rect x="0" y="0" width="980" height="470" fill="url(#dgrid)"/>
 
-<text x="34" y="46" fill="#6faa85" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">TWO FAILURES, TWO RESPONSES</text>
+<text x="34" y="46" fill="#58916d" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">TWO FAILURES, TWO RESPONSES</text>
 <text x="34" y="84" fill="#f2f5f3" font-size="30" font-weight="700">Drift is not hallucination</text>
 
-<rect x="34" y="110" width="440" height="252" fill="url(#dpanel)" stroke="#47514a" stroke-width="1.5"/>
+<rect x="34" y="110" width="440" height="252" fill="url(#dpanel)" stroke="#2e3830" stroke-width="1.5"/>
 <text x="58" y="150" fill="#ecefed" font-size="22" font-weight="700">DRIFT</text>
-<text x="132" y="150" fill="#939a95" font-size="18">a bound was crossed</text>
+<text x="132" y="150" fill="#878e89" font-size="18">a bound was crossed</text>
 
-<rect x="58" y="196" width="216" height="36" fill="url(#band)" stroke="#6faa85" stroke-width="1.2" stroke-dasharray="4 3"/>
-<line x1="58" y1="252" x2="450" y2="252" stroke="#47514a" stroke-width="1.6"/>
+<rect x="58" y="196" width="216" height="36" fill="url(#band)" stroke="#58916d" stroke-width="1.2" stroke-dasharray="4 3"/>
+<line x1="58" y1="252" x2="450" y2="252" stroke="#2e3830" stroke-width="1.6"/>
 <line x1="58" y1="246" x2="58" y2="258" stroke="#949a96" stroke-width="1.6"/>
 <line x1="274" y1="246" x2="274" y2="258" stroke="#949a96" stroke-width="1.6"/>
-<text x="58" y="278" fill="#939a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
-<text x="274" y="278" fill="#939a95" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">20</text>
-<text x="166" y="220" fill="#a5aca7" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">declared range</text>
+<text x="58" y="278" fill="#878e89" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
+<text x="274" y="278" fill="#878e89" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">20</text>
+<text x="166" y="220" fill="#9aa19c" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">declared range</text>
 
 <circle cx="150" cy="252" r="6" fill="#949a96"/>
 <circle cx="424" cy="252" r="8" fill="#e8ebe9"/>
 <text x="424" y="230" fill="#ffffff" font-size="17" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">200</text>
 
-<text x="58" y="316" fill="#ccd2ce" font-size="18">The right kind of value, in the wrong place.</text>
-<text x="58" y="342" fill="#939a95" font-size="17">Widen the bound, retrain, or investigate.</text>
+<text x="58" y="316" fill="#c4cac5" font-size="18">The right kind of value, in the wrong place.</text>
+<text x="58" y="342" fill="#878e89" font-size="17">Widen the bound, retrain, or investigate.</text>
 
 <rect x="506" y="110" width="440" height="252" fill="url(#dpanel)" stroke="url(#dchrome)" stroke-width="2"/>
 <text x="530" y="150" fill="#ffffff" font-size="22" font-weight="700">HALLUCINATION</text>
-<text x="746" y="150" fill="#aeb4af" font-size="18">a value was invented</text>
+<text x="746" y="150" fill="#a4aba6" font-size="18">a value was invented</text>
 
 <g>
-  <rect x="530" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
-  <text x="553" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
-  <rect x="584" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
-  <text x="607" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">1</text>
-  <rect x="638" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
-  <text x="661" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">2</text>
-  <rect x="692" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
-  <text x="715" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">3</text>
-  <rect x="746" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
-  <text x="769" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">4</text>
+  <rect x="530" y="204" width="46" height="46" fill="#0d120e" stroke="#2e3830" stroke-width="1.4"/>
+  <text x="553" y="234" fill="#9aa19c" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
+  <rect x="584" y="204" width="46" height="46" fill="#0d120e" stroke="#2e3830" stroke-width="1.4"/>
+  <text x="607" y="234" fill="#9aa19c" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">1</text>
+  <rect x="638" y="204" width="46" height="46" fill="#0d120e" stroke="#2e3830" stroke-width="1.4"/>
+  <text x="661" y="234" fill="#9aa19c" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">2</text>
+  <rect x="692" y="204" width="46" height="46" fill="#0d120e" stroke="#2e3830" stroke-width="1.4"/>
+  <text x="715" y="234" fill="#9aa19c" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">3</text>
+  <rect x="746" y="204" width="46" height="46" fill="#0d120e" stroke="#2e3830" stroke-width="1.4"/>
+  <text x="769" y="234" fill="#9aa19c" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">4</text>
 </g>
-<text x="530" y="278" fill="#939a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Discrete(5), the whole space</text>
+<text x="530" y="278" fill="#878e89" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Discrete(5), the whole space</text>
 
-<line x1="812" y1="196" x2="812" y2="258" stroke="#4a564d" stroke-width="1.4" stroke-dasharray="5 4"/>
-<rect x="838" y="204" width="82" height="46" fill="#202c23" stroke="#e8ebe9" stroke-width="2"/>
+<line x1="812" y1="196" x2="812" y2="258" stroke="#37423a" stroke-width="1.4" stroke-dasharray="5 4"/>
+<rect x="838" y="204" width="82" height="46" fill="#18211a" stroke="#e8ebe9" stroke-width="2"/>
 <text x="879" y="234" fill="#ffffff" font-size="18" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">999</text>
 
-<text x="530" y="316" fill="#ccd2ce" font-size="18">Never a member of the space at all.</text>
-<text x="530" y="342" fill="#aeb4af" font-size="17">Stop. Do not widen anything to admit it.</text>
+<text x="530" y="316" fill="#c4cac5" font-size="18">Never a member of the space at all.</text>
+<text x="530" y="342" fill="#a4aba6" font-size="17">Stop. Do not widen anything to admit it.</text>
 
-<line x1="34" y1="396" x2="946" y2="396" stroke="#222c25" stroke-width="1"/>
-<text x="34" y="430" fill="#939a95" font-size="17">The left panel is a real bug from this repository: <tspan fill="#e8ebe9" font-weight="700">steps_remaining</tspan> counts down from 200 while the</text>
-<text x="34" y="454" fill="#939a95" font-size="17">declared bound was 20, so every step of every episode reported drift, correctly, and nobody read it.</text>
+<line x1="34" y1="396" x2="946" y2="396" stroke="#1b221d" stroke-width="1"/>
+<text x="34" y="430" fill="#878e89" font-size="17">The left panel is a real bug from this repository: <tspan fill="#e8ebe9" font-weight="700">steps_remaining</tspan> counts down from 200 while the</text>
+<text x="34" y="454" fill="#878e89" font-size="17">declared bound was 20, so every step of every episode reported drift, correctly, and nobody read it.</text>
 </svg>

--- a/assets/drift-vs-hallucination.svg
+++ b/assets/drift-vs-hallucination.svg
@@ -5,15 +5,15 @@
     <stop offset="1" stop-color="#05080c"/>
   </linearGradient>
   <pattern id="dgrid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#16202c"/>
+    <circle cx="1" cy="1" r="0.7" fill="#131b25"/>
   </pattern>
   <linearGradient id="dpanel" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0" stop-color="#1b2431"/>
     <stop offset="1" stop-color="#111820"/>
   </linearGradient>
   <linearGradient id="band" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#7fd4ff" stop-opacity="0.16"/>
-    <stop offset="1" stop-color="#7fd4ff" stop-opacity="0.05"/>
+    <stop offset="0" stop-color="#8ab0cf" stop-opacity="0.16"/>
+    <stop offset="1" stop-color="#8ab0cf" stop-opacity="0.05"/>
   </linearGradient>
   <linearGradient id="dchrome" x1="0" y1="0" x2="1" y2="0">
     <stop offset="0" stop-color="#5d6b7d"/>
@@ -23,17 +23,17 @@
   </linearGradient>
 </defs>
 
-<rect x="0" y="0" width="980" height="470" rx="14" fill="url(#dbg)"/>
-<rect x="0" y="0" width="980" height="470" rx="14" fill="url(#dgrid)"/>
+<rect x="0" y="0" width="980" height="470" fill="url(#dbg)"/>
+<rect x="0" y="0" width="980" height="470" fill="url(#dgrid)"/>
 
-<text x="34" y="46" fill="#7fd4ff" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">TWO FAILURES, TWO RESPONSES</text>
+<text x="34" y="46" fill="#8ab0cf" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">TWO FAILURES, TWO RESPONSES</text>
 <text x="34" y="84" fill="#f4f8fc" font-size="30" font-weight="700">Drift is not hallucination</text>
 
-<rect x="34" y="110" width="440" height="252" rx="6" fill="url(#dpanel)" stroke="#3a4859" stroke-width="1.5"/>
+<rect x="34" y="110" width="440" height="252" fill="url(#dpanel)" stroke="#3a4859" stroke-width="1.5"/>
 <text x="58" y="150" fill="#eef4fa" font-size="22" font-weight="700">DRIFT</text>
 <text x="132" y="150" fill="#8ea0b5" font-size="18">a bound was crossed</text>
 
-<rect x="58" y="196" width="216" height="36" rx="4" fill="url(#band)" stroke="#7fd4ff" stroke-width="1.2" stroke-dasharray="4 3"/>
+<rect x="58" y="196" width="216" height="36" fill="url(#band)" stroke="#8ab0cf" stroke-width="1.2" stroke-dasharray="4 3"/>
 <line x1="58" y1="252" x2="450" y2="252" stroke="#3a4859" stroke-width="1.6"/>
 <line x1="58" y1="246" x2="58" y2="258" stroke="#8fa3ba" stroke-width="1.6"/>
 <line x1="274" y1="246" x2="274" y2="258" stroke="#8fa3ba" stroke-width="1.6"/>
@@ -48,26 +48,26 @@
 <text x="58" y="316" fill="#ccd9e7" font-size="18">The right kind of value, in the wrong place.</text>
 <text x="58" y="342" fill="#8ea0b5" font-size="17">Widen the bound, retrain, or investigate.</text>
 
-<rect x="506" y="110" width="440" height="252" rx="6" fill="url(#dpanel)" stroke="url(#dchrome)" stroke-width="2"/>
+<rect x="506" y="110" width="440" height="252" fill="url(#dpanel)" stroke="url(#dchrome)" stroke-width="2"/>
 <text x="530" y="150" fill="#ffffff" font-size="22" font-weight="700">HALLUCINATION</text>
 <text x="746" y="150" fill="#a9bbcd" font-size="18">a value was invented</text>
 
 <g>
-  <rect x="530" y="204" width="46" height="46" rx="5" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
+  <rect x="530" y="204" width="46" height="46" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
   <text x="553" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
-  <rect x="584" y="204" width="46" height="46" rx="5" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
+  <rect x="584" y="204" width="46" height="46" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
   <text x="607" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">1</text>
-  <rect x="638" y="204" width="46" height="46" rx="5" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
+  <rect x="638" y="204" width="46" height="46" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
   <text x="661" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">2</text>
-  <rect x="692" y="204" width="46" height="46" rx="5" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
+  <rect x="692" y="204" width="46" height="46" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
   <text x="715" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">3</text>
-  <rect x="746" y="204" width="46" height="46" rx="5" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
+  <rect x="746" y="204" width="46" height="46" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
   <text x="769" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">4</text>
 </g>
 <text x="530" y="278" fill="#8ea0b5" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Discrete(5), the whole space</text>
 
 <line x1="812" y1="196" x2="812" y2="258" stroke="#42566b" stroke-width="1.4" stroke-dasharray="5 4"/>
-<rect x="838" y="204" width="82" height="46" rx="5" fill="#26323f" stroke="#eaf2fa" stroke-width="2"/>
+<rect x="838" y="204" width="82" height="46" fill="#26323f" stroke="#eaf2fa" stroke-width="2"/>
 <text x="879" y="234" fill="#ffffff" font-size="18" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">999</text>
 
 <text x="530" y="316" fill="#ccd9e7" font-size="18">Never a member of the space at all.</text>

--- a/assets/drift-vs-hallucination.svg
+++ b/assets/drift-vs-hallucination.svg
@@ -1,79 +1,79 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 470" width="980" height="470" role="img" aria-label="Drift against hallucination. Drift is a value of the right kind landing outside its declared range, shown as 200 sitting far beyond a bound of 20. Hallucination is a value that was never in the space at all, shown as action 999 detached from a five slot discrete space." font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
   <linearGradient id="dbg" x1="0" y1="0" x2="0.5" y2="1">
-    <stop offset="0" stop-color="#060a07"/>
-    <stop offset="1" stop-color="#030503"/>
+    <stop offset="0" stop-color="#0b120e"/>
+    <stop offset="1" stop-color="#050805"/>
   </linearGradient>
   <pattern id="dgrid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#0d130f"/>
+    <circle cx="1" cy="1" r="0.7" fill="#121a14"/>
   </pattern>
   <linearGradient id="dpanel" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#10160f"/>
-    <stop offset="1" stop-color="#0b0f0c"/>
+    <stop offset="0" stop-color="#172018"/>
+    <stop offset="1" stop-color="#0f1510"/>
   </linearGradient>
   <linearGradient id="band" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#58916d" stop-opacity="0.16"/>
-    <stop offset="1" stop-color="#58916d" stop-opacity="0.05"/>
+    <stop offset="0" stop-color="#6faa85" stop-opacity="0.16"/>
+    <stop offset="1" stop-color="#6faa85" stop-opacity="0.05"/>
   </linearGradient>
   <linearGradient id="dchrome" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#5a5f5c"/>
+    <stop offset="0" stop-color="#6d716f"/>
     <stop offset="0.3" stop-color="#e8ebe9"/>
-    <stop offset="0.6" stop-color="#888d8a"/>
-    <stop offset="1" stop-color="#626764"/>
+    <stop offset="0.6" stop-color="#9ba09d"/>
+    <stop offset="1" stop-color="#767b78"/>
   </linearGradient>
 </defs>
 
 <rect x="0" y="0" width="980" height="470" fill="url(#dbg)"/>
 <rect x="0" y="0" width="980" height="470" fill="url(#dgrid)"/>
 
-<text x="34" y="46" fill="#58916d" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">TWO FAILURES, TWO RESPONSES</text>
+<text x="34" y="46" fill="#6faa85" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">TWO FAILURES, TWO RESPONSES</text>
 <text x="34" y="84" fill="#f2f5f3" font-size="30" font-weight="700">Drift is not hallucination</text>
 
-<rect x="34" y="110" width="440" height="252" fill="url(#dpanel)" stroke="#2e3830" stroke-width="1.5"/>
+<rect x="34" y="110" width="440" height="252" fill="url(#dpanel)" stroke="#47514a" stroke-width="1.5"/>
 <text x="58" y="150" fill="#ecefed" font-size="22" font-weight="700">DRIFT</text>
-<text x="132" y="150" fill="#878e89" font-size="18">a bound was crossed</text>
+<text x="132" y="150" fill="#939a95" font-size="18">a bound was crossed</text>
 
-<rect x="58" y="196" width="216" height="36" fill="url(#band)" stroke="#58916d" stroke-width="1.2" stroke-dasharray="4 3"/>
-<line x1="58" y1="252" x2="450" y2="252" stroke="#2e3830" stroke-width="1.6"/>
+<rect x="58" y="196" width="216" height="36" fill="url(#band)" stroke="#6faa85" stroke-width="1.2" stroke-dasharray="4 3"/>
+<line x1="58" y1="252" x2="450" y2="252" stroke="#47514a" stroke-width="1.6"/>
 <line x1="58" y1="246" x2="58" y2="258" stroke="#949a96" stroke-width="1.6"/>
 <line x1="274" y1="246" x2="274" y2="258" stroke="#949a96" stroke-width="1.6"/>
-<text x="58" y="278" fill="#878e89" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
-<text x="274" y="278" fill="#878e89" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">20</text>
-<text x="166" y="220" fill="#9aa19c" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">declared range</text>
+<text x="58" y="278" fill="#939a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
+<text x="274" y="278" fill="#939a95" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">20</text>
+<text x="166" y="220" fill="#a5aca7" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">declared range</text>
 
 <circle cx="150" cy="252" r="6" fill="#949a96"/>
 <circle cx="424" cy="252" r="8" fill="#e8ebe9"/>
 <text x="424" y="230" fill="#ffffff" font-size="17" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">200</text>
 
-<text x="58" y="316" fill="#c4cac5" font-size="18">The right kind of value, in the wrong place.</text>
-<text x="58" y="342" fill="#878e89" font-size="17">Widen the bound, retrain, or investigate.</text>
+<text x="58" y="316" fill="#ccd2ce" font-size="18">The right kind of value, in the wrong place.</text>
+<text x="58" y="342" fill="#939a95" font-size="17">Widen the bound, retrain, or investigate.</text>
 
 <rect x="506" y="110" width="440" height="252" fill="url(#dpanel)" stroke="url(#dchrome)" stroke-width="2"/>
 <text x="530" y="150" fill="#ffffff" font-size="22" font-weight="700">HALLUCINATION</text>
-<text x="746" y="150" fill="#a4aba6" font-size="18">a value was invented</text>
+<text x="746" y="150" fill="#aeb4af" font-size="18">a value was invented</text>
 
 <g>
-  <rect x="530" y="204" width="46" height="46" fill="#0d120e" stroke="#2e3830" stroke-width="1.4"/>
-  <text x="553" y="234" fill="#9aa19c" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
-  <rect x="584" y="204" width="46" height="46" fill="#0d120e" stroke="#2e3830" stroke-width="1.4"/>
-  <text x="607" y="234" fill="#9aa19c" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">1</text>
-  <rect x="638" y="204" width="46" height="46" fill="#0d120e" stroke="#2e3830" stroke-width="1.4"/>
-  <text x="661" y="234" fill="#9aa19c" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">2</text>
-  <rect x="692" y="204" width="46" height="46" fill="#0d120e" stroke="#2e3830" stroke-width="1.4"/>
-  <text x="715" y="234" fill="#9aa19c" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">3</text>
-  <rect x="746" y="204" width="46" height="46" fill="#0d120e" stroke="#2e3830" stroke-width="1.4"/>
-  <text x="769" y="234" fill="#9aa19c" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">4</text>
+  <rect x="530" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
+  <text x="553" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
+  <rect x="584" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
+  <text x="607" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">1</text>
+  <rect x="638" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
+  <text x="661" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">2</text>
+  <rect x="692" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
+  <text x="715" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">3</text>
+  <rect x="746" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
+  <text x="769" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">4</text>
 </g>
-<text x="530" y="278" fill="#878e89" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Discrete(5), the whole space</text>
+<text x="530" y="278" fill="#939a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Discrete(5), the whole space</text>
 
-<line x1="812" y1="196" x2="812" y2="258" stroke="#37423a" stroke-width="1.4" stroke-dasharray="5 4"/>
-<rect x="838" y="204" width="82" height="46" fill="#18211a" stroke="#e8ebe9" stroke-width="2"/>
+<line x1="812" y1="196" x2="812" y2="258" stroke="#4a564d" stroke-width="1.4" stroke-dasharray="5 4"/>
+<rect x="838" y="204" width="82" height="46" fill="#202c23" stroke="#e8ebe9" stroke-width="2"/>
 <text x="879" y="234" fill="#ffffff" font-size="18" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">999</text>
 
-<text x="530" y="316" fill="#c4cac5" font-size="18">Never a member of the space at all.</text>
-<text x="530" y="342" fill="#a4aba6" font-size="17">Stop. Do not widen anything to admit it.</text>
+<text x="530" y="316" fill="#ccd2ce" font-size="18">Never a member of the space at all.</text>
+<text x="530" y="342" fill="#aeb4af" font-size="17">Stop. Do not widen anything to admit it.</text>
 
-<line x1="34" y1="396" x2="946" y2="396" stroke="#1b221d" stroke-width="1"/>
-<text x="34" y="430" fill="#878e89" font-size="17">The left panel is a real bug from this repository: <tspan fill="#e8ebe9" font-weight="700">steps_remaining</tspan> counts down from 200 while the</text>
-<text x="34" y="454" fill="#878e89" font-size="17">declared bound was 20, so every step of every episode reported drift, correctly, and nobody read it.</text>
+<line x1="34" y1="396" x2="946" y2="396" stroke="#222c25" stroke-width="1"/>
+<text x="34" y="430" fill="#939a95" font-size="17">The left panel is a real bug from this repository: <tspan fill="#e8ebe9" font-weight="700">steps_remaining</tspan> counts down from 200 while the</text>
+<text x="34" y="454" fill="#939a95" font-size="17">declared bound was 20, so every step of every episode reported drift, correctly, and nobody read it.</text>
 </svg>

--- a/assets/drift-vs-hallucination.svg
+++ b/assets/drift-vs-hallucination.svg
@@ -1,79 +1,79 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 470" width="980" height="470" role="img" aria-label="Drift against hallucination. Drift is a value of the right kind landing outside its declared range, shown as 200 sitting far beyond a bound of 20. Hallucination is a value that was never in the space at all, shown as action 999 detached from a five slot discrete space." font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
   <linearGradient id="dbg" x1="0" y1="0" x2="0.5" y2="1">
-    <stop offset="0" stop-color="#0d131b"/>
-    <stop offset="1" stop-color="#05080c"/>
+    <stop offset="0" stop-color="#0b120e"/>
+    <stop offset="1" stop-color="#050805"/>
   </linearGradient>
   <pattern id="dgrid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#131b25"/>
+    <circle cx="1" cy="1" r="0.7" fill="#121a14"/>
   </pattern>
   <linearGradient id="dpanel" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#1b2431"/>
-    <stop offset="1" stop-color="#111820"/>
+    <stop offset="0" stop-color="#172018"/>
+    <stop offset="1" stop-color="#0f1510"/>
   </linearGradient>
   <linearGradient id="band" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#8ab0cf" stop-opacity="0.16"/>
-    <stop offset="1" stop-color="#8ab0cf" stop-opacity="0.05"/>
+    <stop offset="0" stop-color="#6faa85" stop-opacity="0.16"/>
+    <stop offset="1" stop-color="#6faa85" stop-opacity="0.05"/>
   </linearGradient>
   <linearGradient id="dchrome" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#5d6b7d"/>
-    <stop offset="0.3" stop-color="#eaf2fa"/>
-    <stop offset="0.6" stop-color="#93a2b4"/>
-    <stop offset="1" stop-color="#66748a"/>
+    <stop offset="0" stop-color="#6d716f"/>
+    <stop offset="0.3" stop-color="#e8ebe9"/>
+    <stop offset="0.6" stop-color="#9ba09d"/>
+    <stop offset="1" stop-color="#767b78"/>
   </linearGradient>
 </defs>
 
 <rect x="0" y="0" width="980" height="470" fill="url(#dbg)"/>
 <rect x="0" y="0" width="980" height="470" fill="url(#dgrid)"/>
 
-<text x="34" y="46" fill="#8ab0cf" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">TWO FAILURES, TWO RESPONSES</text>
-<text x="34" y="84" fill="#f4f8fc" font-size="30" font-weight="700">Drift is not hallucination</text>
+<text x="34" y="46" fill="#6faa85" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">TWO FAILURES, TWO RESPONSES</text>
+<text x="34" y="84" fill="#f2f5f3" font-size="30" font-weight="700">Drift is not hallucination</text>
 
-<rect x="34" y="110" width="440" height="252" fill="url(#dpanel)" stroke="#3a4859" stroke-width="1.5"/>
-<text x="58" y="150" fill="#eef4fa" font-size="22" font-weight="700">DRIFT</text>
-<text x="132" y="150" fill="#8ea0b5" font-size="18">a bound was crossed</text>
+<rect x="34" y="110" width="440" height="252" fill="url(#dpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="58" y="150" fill="#ecefed" font-size="22" font-weight="700">DRIFT</text>
+<text x="132" y="150" fill="#939a95" font-size="18">a bound was crossed</text>
 
-<rect x="58" y="196" width="216" height="36" fill="url(#band)" stroke="#8ab0cf" stroke-width="1.2" stroke-dasharray="4 3"/>
-<line x1="58" y1="252" x2="450" y2="252" stroke="#3a4859" stroke-width="1.6"/>
-<line x1="58" y1="246" x2="58" y2="258" stroke="#8fa3ba" stroke-width="1.6"/>
-<line x1="274" y1="246" x2="274" y2="258" stroke="#8fa3ba" stroke-width="1.6"/>
-<text x="58" y="278" fill="#8ea0b5" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
-<text x="274" y="278" fill="#8ea0b5" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">20</text>
-<text x="166" y="220" fill="#9fb0c3" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">declared range</text>
+<rect x="58" y="196" width="216" height="36" fill="url(#band)" stroke="#6faa85" stroke-width="1.2" stroke-dasharray="4 3"/>
+<line x1="58" y1="252" x2="450" y2="252" stroke="#47514a" stroke-width="1.6"/>
+<line x1="58" y1="246" x2="58" y2="258" stroke="#949a96" stroke-width="1.6"/>
+<line x1="274" y1="246" x2="274" y2="258" stroke="#949a96" stroke-width="1.6"/>
+<text x="58" y="278" fill="#939a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
+<text x="274" y="278" fill="#939a95" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">20</text>
+<text x="166" y="220" fill="#a5aca7" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">declared range</text>
 
-<circle cx="150" cy="252" r="6" fill="#8fa3ba"/>
-<circle cx="424" cy="252" r="8" fill="#eaf2fa"/>
+<circle cx="150" cy="252" r="6" fill="#949a96"/>
+<circle cx="424" cy="252" r="8" fill="#e8ebe9"/>
 <text x="424" y="230" fill="#ffffff" font-size="17" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">200</text>
 
-<text x="58" y="316" fill="#ccd9e7" font-size="18">The right kind of value, in the wrong place.</text>
-<text x="58" y="342" fill="#8ea0b5" font-size="17">Widen the bound, retrain, or investigate.</text>
+<text x="58" y="316" fill="#ccd2ce" font-size="18">The right kind of value, in the wrong place.</text>
+<text x="58" y="342" fill="#939a95" font-size="17">Widen the bound, retrain, or investigate.</text>
 
 <rect x="506" y="110" width="440" height="252" fill="url(#dpanel)" stroke="url(#dchrome)" stroke-width="2"/>
 <text x="530" y="150" fill="#ffffff" font-size="22" font-weight="700">HALLUCINATION</text>
-<text x="746" y="150" fill="#a9bbcd" font-size="18">a value was invented</text>
+<text x="746" y="150" fill="#aeb4af" font-size="18">a value was invented</text>
 
 <g>
-  <rect x="530" y="204" width="46" height="46" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
-  <text x="553" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
-  <rect x="584" y="204" width="46" height="46" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
-  <text x="607" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">1</text>
-  <rect x="638" y="204" width="46" height="46" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
-  <text x="661" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">2</text>
-  <rect x="692" y="204" width="46" height="46" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
-  <text x="715" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">3</text>
-  <rect x="746" y="204" width="46" height="46" fill="#16202c" stroke="#3a4859" stroke-width="1.4"/>
-  <text x="769" y="234" fill="#9fb0c3" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">4</text>
+  <rect x="530" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
+  <text x="553" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">0</text>
+  <rect x="584" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
+  <text x="607" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">1</text>
+  <rect x="638" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
+  <text x="661" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">2</text>
+  <rect x="692" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
+  <text x="715" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">3</text>
+  <rect x="746" y="204" width="46" height="46" fill="#141c16" stroke="#47514a" stroke-width="1.4"/>
+  <text x="769" y="234" fill="#a5aca7" font-size="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">4</text>
 </g>
-<text x="530" y="278" fill="#8ea0b5" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Discrete(5), the whole space</text>
+<text x="530" y="278" fill="#939a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Discrete(5), the whole space</text>
 
-<line x1="812" y1="196" x2="812" y2="258" stroke="#42566b" stroke-width="1.4" stroke-dasharray="5 4"/>
-<rect x="838" y="204" width="82" height="46" fill="#26323f" stroke="#eaf2fa" stroke-width="2"/>
+<line x1="812" y1="196" x2="812" y2="258" stroke="#4a564d" stroke-width="1.4" stroke-dasharray="5 4"/>
+<rect x="838" y="204" width="82" height="46" fill="#202c23" stroke="#e8ebe9" stroke-width="2"/>
 <text x="879" y="234" fill="#ffffff" font-size="18" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">999</text>
 
-<text x="530" y="316" fill="#ccd9e7" font-size="18">Never a member of the space at all.</text>
-<text x="530" y="342" fill="#a9bbcd" font-size="17">Stop. Do not widen anything to admit it.</text>
+<text x="530" y="316" fill="#ccd2ce" font-size="18">Never a member of the space at all.</text>
+<text x="530" y="342" fill="#aeb4af" font-size="17">Stop. Do not widen anything to admit it.</text>
 
-<line x1="34" y1="396" x2="946" y2="396" stroke="#1e2a37" stroke-width="1"/>
-<text x="34" y="430" fill="#8ea0b5" font-size="17">The left panel is a real bug from this repository: <tspan fill="#eaf2fa" font-weight="700">steps_remaining</tspan> counts down from 200 while the</text>
-<text x="34" y="454" fill="#8ea0b5" font-size="17">declared bound was 20, so every step of every episode reported drift, correctly, and nobody read it.</text>
+<line x1="34" y1="396" x2="946" y2="396" stroke="#222c25" stroke-width="1"/>
+<text x="34" y="430" fill="#939a95" font-size="17">The left panel is a real bug from this repository: <tspan fill="#e8ebe9" font-weight="700">steps_remaining</tspan> counts down from 200 while the</text>
+<text x="34" y="454" fill="#939a95" font-size="17">declared bound was 20, so every step of every episode reported drift, correctly, and nobody read it.</text>
 </svg>

--- a/assets/hero.svg
+++ b/assets/hero.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 300" width="980" height="300" role="img" aria-label="Multi-agent RL MAPF drone navigation: a PPO agent that validates its own policy outputs, shown beside a grid world with a path from origin to goal under a validator scan frame" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="hbg" x1="0" y1="0" x2="0.7" y2="1">
+    <stop offset="0" stop-color="#0e151e"/>
+    <stop offset="0.6" stop-color="#080c12"/>
+    <stop offset="1" stop-color="#04070a"/>
+  </linearGradient>
+  <pattern id="hgrid" width="26" height="26" patternUnits="userSpaceOnUse">
+    <circle cx="1" cy="1" r="0.7" fill="#16202c"/>
+  </pattern>
+  <linearGradient id="hchrome" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#5d6b7d"/>
+    <stop offset="0.3" stop-color="#eaf2fa"/>
+    <stop offset="0.55" stop-color="#93a2b4"/>
+    <stop offset="0.8" stop-color="#f2f8ff"/>
+    <stop offset="1" stop-color="#66748a"/>
+  </linearGradient>
+  <linearGradient id="hrule" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#7fd4ff" stop-opacity="0.9"/>
+    <stop offset="1" stop-color="#7fd4ff" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="chip" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#1b2431"/>
+    <stop offset="1" stop-color="#111820"/>
+  </linearGradient>
+</defs>
+
+<rect x="0" y="0" width="980" height="300" rx="14" fill="url(#hbg)"/>
+<rect x="0" y="0" width="980" height="300" rx="14" fill="url(#hgrid)"/>
+
+<text x="46" y="62" fill="#7fd4ff" font-size="15" font-weight="700" letter-spacing="3.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">REINFORCEMENT LEARNING / INTEGRITY</text>
+
+<text x="46" y="116" fill="#f4f8fc" font-size="40" font-weight="700" letter-spacing="0.3">Drone navigation that</text>
+<text x="46" y="162" fill="#f4f8fc" font-size="40" font-weight="700" letter-spacing="0.3">checks its own work</text>
+
+<rect x="46" y="182" width="150" height="2.5" fill="url(#hrule)"/>
+
+<text x="46" y="216" fill="#9fb0c3" font-size="19">A PPO agent on a grid world, wrapped in a validator layer that</text>
+<text x="46" y="242" fill="#9fb0c3" font-size="19">separates <tspan fill="#eaf2fa" font-weight="700">drift</tspan> from <tspan fill="#eaf2fa" font-weight="700">hallucination</tspan> on every single step.</text>
+
+<rect x="46" y="262" width="128" height="26" rx="5" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
+<text x="110" y="280" fill="#9fb0c3" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">observe</text>
+<rect x="182" y="262" width="112" height="26" rx="5" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
+<text x="238" y="280" fill="#9fb0c3" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">policy</text>
+<rect x="302" y="262" width="124" height="26" rx="5" fill="#1d2a36" stroke="url(#hchrome)" stroke-width="1.8"/>
+<text x="364" y="280" fill="#eaf2fa" font-size="15" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">validate</text>
+<rect x="434" y="262" width="92" height="26" rx="5" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
+<text x="480" y="280" fill="#9fb0c3" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">act</text>
+
+<g transform="translate(646,44)">
+  <rect x="0" y="0" width="288" height="216" rx="8" fill="#0a1018" stroke="#2b3949" stroke-width="1.4"/>
+
+  <g stroke="#17222f" stroke-width="1">
+    <line x1="24" y1="24" x2="264" y2="24"/><line x1="24" y1="56" x2="264" y2="56"/>
+    <line x1="24" y1="88" x2="264" y2="88"/><line x1="24" y1="120" x2="264" y2="120"/>
+    <line x1="24" y1="152" x2="264" y2="152"/><line x1="24" y1="184" x2="264" y2="184"/>
+    <line x1="24" y1="24" x2="24" y2="184"/><line x1="64" y1="24" x2="64" y2="184"/>
+    <line x1="104" y1="24" x2="104" y2="184"/><line x1="144" y1="24" x2="144" y2="184"/>
+    <line x1="184" y1="24" x2="184" y2="184"/><line x1="224" y1="24" x2="224" y2="184"/>
+    <line x1="264" y1="24" x2="264" y2="184"/>
+  </g>
+
+  <path d="M 24 184 L 64 184 L 64 152 L 104 152 L 104 120 L 144 120 L 144 88 L 184 88 L 184 56 L 224 56 L 224 24 L 264 24"
+        stroke="#7fd4ff" stroke-width="2.6" fill="none" stroke-linejoin="round" stroke-linecap="round" opacity="0.9"/>
+
+  <circle cx="24" cy="184" r="6.5" fill="#eaf2fa"/>
+  <rect x="257" y="17" width="14" height="14" rx="3" fill="none" stroke="#eaf2fa" stroke-width="2.4"/>
+
+  <path d="M 12 26 L 12 12 L 26 12" stroke="#7fd4ff" stroke-width="2" fill="none"/>
+  <path d="M 276 190 L 276 204 L 262 204" stroke="#7fd4ff" stroke-width="2" fill="none"/>
+
+  <text x="144" y="208" fill="#6d7d90" font-size="14.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">origin to goal, 38 moves</text>
+</g>
+</svg>

--- a/assets/hero.svg
+++ b/assets/hero.svg
@@ -1,56 +1,56 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 300" width="980" height="300" role="img" aria-label="Multi-agent RL MAPF drone navigation: a PPO agent that validates its own policy outputs, shown beside a grid world with a path from origin to goal under a validator scan frame" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
   <linearGradient id="hbg" x1="0" y1="0" x2="0.7" y2="1">
-    <stop offset="0" stop-color="#0e151e"/>
-    <stop offset="0.6" stop-color="#080c12"/>
-    <stop offset="1" stop-color="#04070a"/>
+    <stop offset="0" stop-color="#0b120e"/>
+    <stop offset="0.6" stop-color="#070b08"/>
+    <stop offset="1" stop-color="#040705"/>
   </linearGradient>
   <pattern id="hgrid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#131b25"/>
+    <circle cx="1" cy="1" r="0.7" fill="#121a14"/>
   </pattern>
   <linearGradient id="hchrome" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#5d6b7d"/>
-    <stop offset="0.3" stop-color="#eaf2fa"/>
-    <stop offset="0.55" stop-color="#93a2b4"/>
-    <stop offset="0.8" stop-color="#f2f8ff"/>
-    <stop offset="1" stop-color="#66748a"/>
+    <stop offset="0" stop-color="#6d716f"/>
+    <stop offset="0.3" stop-color="#e8ebe9"/>
+    <stop offset="0.55" stop-color="#9ba09d"/>
+    <stop offset="0.8" stop-color="#fafbfa"/>
+    <stop offset="1" stop-color="#767b78"/>
   </linearGradient>
   <linearGradient id="hrule" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#8ab0cf" stop-opacity="0.9"/>
-    <stop offset="1" stop-color="#8ab0cf" stop-opacity="0"/>
+    <stop offset="0" stop-color="#6faa85" stop-opacity="0.9"/>
+    <stop offset="1" stop-color="#6faa85" stop-opacity="0"/>
   </linearGradient>
   <linearGradient id="chip" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#1b2431"/>
-    <stop offset="1" stop-color="#111820"/>
+    <stop offset="0" stop-color="#172018"/>
+    <stop offset="1" stop-color="#0f1510"/>
   </linearGradient>
 </defs>
 
 <rect x="0" y="0" width="980" height="300" fill="url(#hbg)"/>
 <rect x="0" y="0" width="980" height="300" fill="url(#hgrid)"/>
 
-<text x="46" y="62" fill="#8ab0cf" font-size="15" font-weight="700" letter-spacing="3.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">REINFORCEMENT LEARNING / INTEGRITY</text>
+<text x="46" y="62" fill="#6faa85" font-size="15" font-weight="700" letter-spacing="3.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">REINFORCEMENT LEARNING / INTEGRITY</text>
 
-<text x="46" y="116" fill="#f4f8fc" font-size="40" font-weight="700" letter-spacing="0.3">Drone navigation that</text>
-<text x="46" y="162" fill="#f4f8fc" font-size="40" font-weight="700" letter-spacing="0.3">checks its own work</text>
+<text x="46" y="116" fill="#f2f5f3" font-size="40" font-weight="700" letter-spacing="0.3">Drone navigation that</text>
+<text x="46" y="162" fill="#f2f5f3" font-size="40" font-weight="700" letter-spacing="0.3">checks its own work</text>
 
 <rect x="46" y="182" width="150" height="2.5" fill="url(#hrule)"/>
 
-<text x="46" y="216" fill="#9fb0c3" font-size="19">A PPO agent on a grid world, wrapped in a validator layer that</text>
-<text x="46" y="242" fill="#9fb0c3" font-size="19">separates <tspan fill="#eaf2fa" font-weight="700">drift</tspan> from <tspan fill="#eaf2fa" font-weight="700">hallucination</tspan> on every single step.</text>
+<text x="46" y="216" fill="#a5aca7" font-size="19">A PPO agent on a grid world, wrapped in a validator layer that</text>
+<text x="46" y="242" fill="#a5aca7" font-size="19">separates <tspan fill="#e8ebe9" font-weight="700">drift</tspan> from <tspan fill="#e8ebe9" font-weight="700">hallucination</tspan> on every single step.</text>
 
-<rect x="46" y="262" width="128" height="26" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
-<text x="110" y="280" fill="#9fb0c3" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">observe</text>
-<rect x="182" y="262" width="112" height="26" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
-<text x="238" y="280" fill="#9fb0c3" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">policy</text>
-<rect x="302" y="262" width="124" height="26" fill="#1d2a36" stroke="url(#hchrome)" stroke-width="1.8"/>
-<text x="364" y="280" fill="#eaf2fa" font-size="15" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">validate</text>
-<rect x="434" y="262" width="92" height="26" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
-<text x="480" y="280" fill="#9fb0c3" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">act</text>
+<rect x="46" y="262" width="128" height="26" fill="url(#chip)" stroke="#47514a" stroke-width="1.2"/>
+<text x="110" y="280" fill="#a5aca7" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">observe</text>
+<rect x="182" y="262" width="112" height="26" fill="url(#chip)" stroke="#47514a" stroke-width="1.2"/>
+<text x="238" y="280" fill="#a5aca7" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">policy</text>
+<rect x="302" y="262" width="124" height="26" fill="#1a241c" stroke="url(#hchrome)" stroke-width="1.8"/>
+<text x="364" y="280" fill="#e8ebe9" font-size="15" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">validate</text>
+<rect x="434" y="262" width="92" height="26" fill="url(#chip)" stroke="#47514a" stroke-width="1.2"/>
+<text x="480" y="280" fill="#a5aca7" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">act</text>
 
 <g transform="translate(646,44)">
-  <rect x="0" y="0" width="288" height="216" fill="#0a1018" stroke="#2b3949" stroke-width="1.4"/>
+  <rect x="0" y="0" width="288" height="216" fill="#080e0a" stroke="#333d36" stroke-width="1.4"/>
 
-  <g stroke="#17222f" stroke-width="1">
+  <g stroke="#16201a" stroke-width="1">
     <line x1="24" y1="24" x2="264" y2="24"/><line x1="24" y1="56" x2="264" y2="56"/>
     <line x1="24" y1="88" x2="264" y2="88"/><line x1="24" y1="120" x2="264" y2="120"/>
     <line x1="24" y1="152" x2="264" y2="152"/><line x1="24" y1="184" x2="264" y2="184"/>
@@ -61,11 +61,11 @@
   </g>
 
   <path d="M 24 184 L 64 184 L 64 152 L 104 152 L 104 120 L 144 120 L 144 88 L 184 88 L 184 56 L 224 56 L 224 24 L 264 24"
-        stroke="#8ab0cf" stroke-width="2.6" fill="none" stroke-linejoin="miter" opacity="0.9"/>
+        stroke="#6faa85" stroke-width="2.6" fill="none" stroke-linejoin="miter" opacity="0.9"/>
 
-  <circle cx="24" cy="184" r="6.5" fill="#eaf2fa"/>
-  <rect x="257" y="17" width="14" height="14" fill="none" stroke="#eaf2fa" stroke-width="2.4"/>
+  <circle cx="24" cy="184" r="6.5" fill="#e8ebe9"/>
+  <rect x="257" y="17" width="14" height="14" fill="none" stroke="#e8ebe9" stroke-width="2.4"/>
 
-  <text x="144" y="208" fill="#6d7d90" font-size="14.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">origin to goal, 38 moves</text>
+  <text x="144" y="208" fill="#757c77" font-size="14.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">origin to goal, 38 moves</text>
 </g>
 </svg>

--- a/assets/hero.svg
+++ b/assets/hero.svg
@@ -1,56 +1,56 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 300" width="980" height="300" role="img" aria-label="Multi-agent RL MAPF drone navigation: a PPO agent that validates its own policy outputs, shown beside a grid world with a path from origin to goal under a validator scan frame" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
   <linearGradient id="hbg" x1="0" y1="0" x2="0.7" y2="1">
-    <stop offset="0" stop-color="#060a07"/>
-    <stop offset="0.6" stop-color="#040705"/>
-    <stop offset="1" stop-color="#020403"/>
+    <stop offset="0" stop-color="#0b120e"/>
+    <stop offset="0.6" stop-color="#070b08"/>
+    <stop offset="1" stop-color="#040705"/>
   </linearGradient>
   <pattern id="hgrid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#0d130f"/>
+    <circle cx="1" cy="1" r="0.7" fill="#121a14"/>
   </pattern>
   <linearGradient id="hchrome" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#5a5f5c"/>
+    <stop offset="0" stop-color="#6d716f"/>
     <stop offset="0.3" stop-color="#e8ebe9"/>
-    <stop offset="0.55" stop-color="#888d8a"/>
+    <stop offset="0.55" stop-color="#9ba09d"/>
     <stop offset="0.8" stop-color="#fafbfa"/>
-    <stop offset="1" stop-color="#626764"/>
+    <stop offset="1" stop-color="#767b78"/>
   </linearGradient>
   <linearGradient id="hrule" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#58916d" stop-opacity="0.9"/>
-    <stop offset="1" stop-color="#58916d" stop-opacity="0"/>
+    <stop offset="0" stop-color="#6faa85" stop-opacity="0.9"/>
+    <stop offset="1" stop-color="#6faa85" stop-opacity="0"/>
   </linearGradient>
   <linearGradient id="chip" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#10160f"/>
-    <stop offset="1" stop-color="#0b0f0c"/>
+    <stop offset="0" stop-color="#172018"/>
+    <stop offset="1" stop-color="#0f1510"/>
   </linearGradient>
 </defs>
 
 <rect x="0" y="0" width="980" height="300" fill="url(#hbg)"/>
 <rect x="0" y="0" width="980" height="300" fill="url(#hgrid)"/>
 
-<text x="46" y="62" fill="#58916d" font-size="15" font-weight="700" letter-spacing="3.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">REINFORCEMENT LEARNING / INTEGRITY</text>
+<text x="46" y="62" fill="#6faa85" font-size="15" font-weight="700" letter-spacing="3.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">REINFORCEMENT LEARNING / INTEGRITY</text>
 
 <text x="46" y="116" fill="#f2f5f3" font-size="40" font-weight="700" letter-spacing="0.3">Drone navigation that</text>
 <text x="46" y="162" fill="#f2f5f3" font-size="40" font-weight="700" letter-spacing="0.3">checks its own work</text>
 
 <rect x="46" y="182" width="150" height="2.5" fill="url(#hrule)"/>
 
-<text x="46" y="216" fill="#9aa19c" font-size="19">A PPO agent on a grid world, wrapped in a validator layer that</text>
-<text x="46" y="242" fill="#9aa19c" font-size="19">separates <tspan fill="#e8ebe9" font-weight="700">drift</tspan> from <tspan fill="#e8ebe9" font-weight="700">hallucination</tspan> on every single step.</text>
+<text x="46" y="216" fill="#a5aca7" font-size="19">A PPO agent on a grid world, wrapped in a validator layer that</text>
+<text x="46" y="242" fill="#a5aca7" font-size="19">separates <tspan fill="#e8ebe9" font-weight="700">drift</tspan> from <tspan fill="#e8ebe9" font-weight="700">hallucination</tspan> on every single step.</text>
 
-<rect x="46" y="262" width="128" height="26" fill="url(#chip)" stroke="#2e3830" stroke-width="1.2"/>
-<text x="110" y="280" fill="#9aa19c" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">observe</text>
-<rect x="182" y="262" width="112" height="26" fill="url(#chip)" stroke="#2e3830" stroke-width="1.2"/>
-<text x="238" y="280" fill="#9aa19c" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">policy</text>
-<rect x="302" y="262" width="124" height="26" fill="#131a15" stroke="url(#hchrome)" stroke-width="1.8"/>
+<rect x="46" y="262" width="128" height="26" fill="url(#chip)" stroke="#47514a" stroke-width="1.2"/>
+<text x="110" y="280" fill="#a5aca7" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">observe</text>
+<rect x="182" y="262" width="112" height="26" fill="url(#chip)" stroke="#47514a" stroke-width="1.2"/>
+<text x="238" y="280" fill="#a5aca7" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">policy</text>
+<rect x="302" y="262" width="124" height="26" fill="#1a241c" stroke="url(#hchrome)" stroke-width="1.8"/>
 <text x="364" y="280" fill="#e8ebe9" font-size="15" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">validate</text>
-<rect x="434" y="262" width="92" height="26" fill="url(#chip)" stroke="#2e3830" stroke-width="1.2"/>
-<text x="480" y="280" fill="#9aa19c" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">act</text>
+<rect x="434" y="262" width="92" height="26" fill="url(#chip)" stroke="#47514a" stroke-width="1.2"/>
+<text x="480" y="280" fill="#a5aca7" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">act</text>
 
 <g transform="translate(646,44)">
-  <rect x="0" y="0" width="288" height="216" fill="#050806" stroke="#232b25" stroke-width="1.4"/>
+  <rect x="0" y="0" width="288" height="216" fill="#080e0a" stroke="#333d36" stroke-width="1.4"/>
 
-  <g stroke="#111814" stroke-width="1">
+  <g stroke="#16201a" stroke-width="1">
     <line x1="24" y1="24" x2="264" y2="24"/><line x1="24" y1="56" x2="264" y2="56"/>
     <line x1="24" y1="88" x2="264" y2="88"/><line x1="24" y1="120" x2="264" y2="120"/>
     <line x1="24" y1="152" x2="264" y2="152"/><line x1="24" y1="184" x2="264" y2="184"/>
@@ -61,11 +61,11 @@
   </g>
 
   <path d="M 24 184 L 64 184 L 64 152 L 104 152 L 104 120 L 144 120 L 144 88 L 184 88 L 184 56 L 224 56 L 224 24 L 264 24"
-        stroke="#58916d" stroke-width="2.6" fill="none" stroke-linejoin="miter" opacity="0.9"/>
+        stroke="#6faa85" stroke-width="2.6" fill="none" stroke-linejoin="miter" opacity="0.9"/>
 
   <circle cx="24" cy="184" r="6.5" fill="#e8ebe9"/>
   <rect x="257" y="17" width="14" height="14" fill="none" stroke="#e8ebe9" stroke-width="2.4"/>
 
-  <text x="144" y="208" fill="#6b726d" font-size="14.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">origin to goal, 38 moves</text>
+  <text x="144" y="208" fill="#757c77" font-size="14.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">origin to goal, 38 moves</text>
 </g>
 </svg>

--- a/assets/hero.svg
+++ b/assets/hero.svg
@@ -6,7 +6,7 @@
     <stop offset="1" stop-color="#04070a"/>
   </linearGradient>
   <pattern id="hgrid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#16202c"/>
+    <circle cx="1" cy="1" r="0.7" fill="#131b25"/>
   </pattern>
   <linearGradient id="hchrome" x1="0" y1="0" x2="1" y2="0">
     <stop offset="0" stop-color="#5d6b7d"/>
@@ -16,8 +16,8 @@
     <stop offset="1" stop-color="#66748a"/>
   </linearGradient>
   <linearGradient id="hrule" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#7fd4ff" stop-opacity="0.9"/>
-    <stop offset="1" stop-color="#7fd4ff" stop-opacity="0"/>
+    <stop offset="0" stop-color="#8ab0cf" stop-opacity="0.9"/>
+    <stop offset="1" stop-color="#8ab0cf" stop-opacity="0"/>
   </linearGradient>
   <linearGradient id="chip" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0" stop-color="#1b2431"/>
@@ -25,10 +25,10 @@
   </linearGradient>
 </defs>
 
-<rect x="0" y="0" width="980" height="300" rx="14" fill="url(#hbg)"/>
-<rect x="0" y="0" width="980" height="300" rx="14" fill="url(#hgrid)"/>
+<rect x="0" y="0" width="980" height="300" fill="url(#hbg)"/>
+<rect x="0" y="0" width="980" height="300" fill="url(#hgrid)"/>
 
-<text x="46" y="62" fill="#7fd4ff" font-size="15" font-weight="700" letter-spacing="3.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">REINFORCEMENT LEARNING / INTEGRITY</text>
+<text x="46" y="62" fill="#8ab0cf" font-size="15" font-weight="700" letter-spacing="3.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">REINFORCEMENT LEARNING / INTEGRITY</text>
 
 <text x="46" y="116" fill="#f4f8fc" font-size="40" font-weight="700" letter-spacing="0.3">Drone navigation that</text>
 <text x="46" y="162" fill="#f4f8fc" font-size="40" font-weight="700" letter-spacing="0.3">checks its own work</text>
@@ -38,17 +38,17 @@
 <text x="46" y="216" fill="#9fb0c3" font-size="19">A PPO agent on a grid world, wrapped in a validator layer that</text>
 <text x="46" y="242" fill="#9fb0c3" font-size="19">separates <tspan fill="#eaf2fa" font-weight="700">drift</tspan> from <tspan fill="#eaf2fa" font-weight="700">hallucination</tspan> on every single step.</text>
 
-<rect x="46" y="262" width="128" height="26" rx="5" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
+<rect x="46" y="262" width="128" height="26" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
 <text x="110" y="280" fill="#9fb0c3" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">observe</text>
-<rect x="182" y="262" width="112" height="26" rx="5" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
+<rect x="182" y="262" width="112" height="26" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
 <text x="238" y="280" fill="#9fb0c3" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">policy</text>
-<rect x="302" y="262" width="124" height="26" rx="5" fill="#1d2a36" stroke="url(#hchrome)" stroke-width="1.8"/>
+<rect x="302" y="262" width="124" height="26" fill="#1d2a36" stroke="url(#hchrome)" stroke-width="1.8"/>
 <text x="364" y="280" fill="#eaf2fa" font-size="15" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">validate</text>
-<rect x="434" y="262" width="92" height="26" rx="5" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
+<rect x="434" y="262" width="92" height="26" fill="url(#chip)" stroke="#3a4859" stroke-width="1.2"/>
 <text x="480" y="280" fill="#9fb0c3" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">act</text>
 
 <g transform="translate(646,44)">
-  <rect x="0" y="0" width="288" height="216" rx="8" fill="#0a1018" stroke="#2b3949" stroke-width="1.4"/>
+  <rect x="0" y="0" width="288" height="216" fill="#0a1018" stroke="#2b3949" stroke-width="1.4"/>
 
   <g stroke="#17222f" stroke-width="1">
     <line x1="24" y1="24" x2="264" y2="24"/><line x1="24" y1="56" x2="264" y2="56"/>
@@ -61,13 +61,10 @@
   </g>
 
   <path d="M 24 184 L 64 184 L 64 152 L 104 152 L 104 120 L 144 120 L 144 88 L 184 88 L 184 56 L 224 56 L 224 24 L 264 24"
-        stroke="#7fd4ff" stroke-width="2.6" fill="none" stroke-linejoin="round" stroke-linecap="round" opacity="0.9"/>
+        stroke="#8ab0cf" stroke-width="2.6" fill="none" stroke-linejoin="miter" opacity="0.9"/>
 
   <circle cx="24" cy="184" r="6.5" fill="#eaf2fa"/>
-  <rect x="257" y="17" width="14" height="14" rx="3" fill="none" stroke="#eaf2fa" stroke-width="2.4"/>
-
-  <path d="M 12 26 L 12 12 L 26 12" stroke="#7fd4ff" stroke-width="2" fill="none"/>
-  <path d="M 276 190 L 276 204 L 262 204" stroke="#7fd4ff" stroke-width="2" fill="none"/>
+  <rect x="257" y="17" width="14" height="14" fill="none" stroke="#eaf2fa" stroke-width="2.4"/>
 
   <text x="144" y="208" fill="#6d7d90" font-size="14.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">origin to goal, 38 moves</text>
 </g>

--- a/assets/hero.svg
+++ b/assets/hero.svg
@@ -1,56 +1,56 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 300" width="980" height="300" role="img" aria-label="Multi-agent RL MAPF drone navigation: a PPO agent that validates its own policy outputs, shown beside a grid world with a path from origin to goal under a validator scan frame" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
   <linearGradient id="hbg" x1="0" y1="0" x2="0.7" y2="1">
-    <stop offset="0" stop-color="#0b120e"/>
-    <stop offset="0.6" stop-color="#070b08"/>
-    <stop offset="1" stop-color="#040705"/>
+    <stop offset="0" stop-color="#060a07"/>
+    <stop offset="0.6" stop-color="#040705"/>
+    <stop offset="1" stop-color="#020403"/>
   </linearGradient>
   <pattern id="hgrid" width="26" height="26" patternUnits="userSpaceOnUse">
-    <circle cx="1" cy="1" r="0.7" fill="#121a14"/>
+    <circle cx="1" cy="1" r="0.7" fill="#0d130f"/>
   </pattern>
   <linearGradient id="hchrome" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#6d716f"/>
+    <stop offset="0" stop-color="#5a5f5c"/>
     <stop offset="0.3" stop-color="#e8ebe9"/>
-    <stop offset="0.55" stop-color="#9ba09d"/>
+    <stop offset="0.55" stop-color="#888d8a"/>
     <stop offset="0.8" stop-color="#fafbfa"/>
-    <stop offset="1" stop-color="#767b78"/>
+    <stop offset="1" stop-color="#626764"/>
   </linearGradient>
   <linearGradient id="hrule" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#6faa85" stop-opacity="0.9"/>
-    <stop offset="1" stop-color="#6faa85" stop-opacity="0"/>
+    <stop offset="0" stop-color="#58916d" stop-opacity="0.9"/>
+    <stop offset="1" stop-color="#58916d" stop-opacity="0"/>
   </linearGradient>
   <linearGradient id="chip" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#172018"/>
-    <stop offset="1" stop-color="#0f1510"/>
+    <stop offset="0" stop-color="#10160f"/>
+    <stop offset="1" stop-color="#0b0f0c"/>
   </linearGradient>
 </defs>
 
 <rect x="0" y="0" width="980" height="300" fill="url(#hbg)"/>
 <rect x="0" y="0" width="980" height="300" fill="url(#hgrid)"/>
 
-<text x="46" y="62" fill="#6faa85" font-size="15" font-weight="700" letter-spacing="3.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">REINFORCEMENT LEARNING / INTEGRITY</text>
+<text x="46" y="62" fill="#58916d" font-size="15" font-weight="700" letter-spacing="3.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">REINFORCEMENT LEARNING / INTEGRITY</text>
 
 <text x="46" y="116" fill="#f2f5f3" font-size="40" font-weight="700" letter-spacing="0.3">Drone navigation that</text>
 <text x="46" y="162" fill="#f2f5f3" font-size="40" font-weight="700" letter-spacing="0.3">checks its own work</text>
 
 <rect x="46" y="182" width="150" height="2.5" fill="url(#hrule)"/>
 
-<text x="46" y="216" fill="#a5aca7" font-size="19">A PPO agent on a grid world, wrapped in a validator layer that</text>
-<text x="46" y="242" fill="#a5aca7" font-size="19">separates <tspan fill="#e8ebe9" font-weight="700">drift</tspan> from <tspan fill="#e8ebe9" font-weight="700">hallucination</tspan> on every single step.</text>
+<text x="46" y="216" fill="#9aa19c" font-size="19">A PPO agent on a grid world, wrapped in a validator layer that</text>
+<text x="46" y="242" fill="#9aa19c" font-size="19">separates <tspan fill="#e8ebe9" font-weight="700">drift</tspan> from <tspan fill="#e8ebe9" font-weight="700">hallucination</tspan> on every single step.</text>
 
-<rect x="46" y="262" width="128" height="26" fill="url(#chip)" stroke="#47514a" stroke-width="1.2"/>
-<text x="110" y="280" fill="#a5aca7" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">observe</text>
-<rect x="182" y="262" width="112" height="26" fill="url(#chip)" stroke="#47514a" stroke-width="1.2"/>
-<text x="238" y="280" fill="#a5aca7" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">policy</text>
-<rect x="302" y="262" width="124" height="26" fill="#1a241c" stroke="url(#hchrome)" stroke-width="1.8"/>
+<rect x="46" y="262" width="128" height="26" fill="url(#chip)" stroke="#2e3830" stroke-width="1.2"/>
+<text x="110" y="280" fill="#9aa19c" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">observe</text>
+<rect x="182" y="262" width="112" height="26" fill="url(#chip)" stroke="#2e3830" stroke-width="1.2"/>
+<text x="238" y="280" fill="#9aa19c" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">policy</text>
+<rect x="302" y="262" width="124" height="26" fill="#131a15" stroke="url(#hchrome)" stroke-width="1.8"/>
 <text x="364" y="280" fill="#e8ebe9" font-size="15" text-anchor="middle" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">validate</text>
-<rect x="434" y="262" width="92" height="26" fill="url(#chip)" stroke="#47514a" stroke-width="1.2"/>
-<text x="480" y="280" fill="#a5aca7" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">act</text>
+<rect x="434" y="262" width="92" height="26" fill="url(#chip)" stroke="#2e3830" stroke-width="1.2"/>
+<text x="480" y="280" fill="#9aa19c" font-size="15" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">act</text>
 
 <g transform="translate(646,44)">
-  <rect x="0" y="0" width="288" height="216" fill="#080e0a" stroke="#333d36" stroke-width="1.4"/>
+  <rect x="0" y="0" width="288" height="216" fill="#050806" stroke="#232b25" stroke-width="1.4"/>
 
-  <g stroke="#16201a" stroke-width="1">
+  <g stroke="#111814" stroke-width="1">
     <line x1="24" y1="24" x2="264" y2="24"/><line x1="24" y1="56" x2="264" y2="56"/>
     <line x1="24" y1="88" x2="264" y2="88"/><line x1="24" y1="120" x2="264" y2="120"/>
     <line x1="24" y1="152" x2="264" y2="152"/><line x1="24" y1="184" x2="264" y2="184"/>
@@ -61,11 +61,11 @@
   </g>
 
   <path d="M 24 184 L 64 184 L 64 152 L 104 152 L 104 120 L 144 120 L 144 88 L 184 88 L 184 56 L 224 56 L 224 24 L 264 24"
-        stroke="#6faa85" stroke-width="2.6" fill="none" stroke-linejoin="miter" opacity="0.9"/>
+        stroke="#58916d" stroke-width="2.6" fill="none" stroke-linejoin="miter" opacity="0.9"/>
 
   <circle cx="24" cy="184" r="6.5" fill="#e8ebe9"/>
   <rect x="257" y="17" width="14" height="14" fill="none" stroke="#e8ebe9" stroke-width="2.4"/>
 
-  <text x="144" y="208" fill="#757c77" font-size="14.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">origin to goal, 38 moves</text>
+  <text x="144" y="208" fill="#6b726d" font-size="14.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">origin to goal, 38 moves</text>
 </g>
 </svg>

--- a/assets/low-level-design.svg
+++ b/assets/low-level-design.svg
@@ -1,0 +1,132 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 1300" width="980" height="1300" role="img" aria-label="Low level design: an on-drone actor pipeline from ingestion through preprocess and policy to a safety controller, bounded queues between each stage, gRPC and REST interfaces to a server side of ingest gateway, stream processor, analytics, weight learner and config API, under a 25 millisecond per-tick budget" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="lbg" x1="0" y1="0" x2="0.4" y2="1">
+    <stop offset="0" stop-color="#0b120e"/>
+    <stop offset="0.55" stop-color="#070b08"/>
+    <stop offset="1" stop-color="#040705"/>
+  </linearGradient>
+  <pattern id="lgrid" width="26" height="26" patternUnits="userSpaceOnUse">
+    <circle cx="1" cy="1" r="0.7" fill="#121a14"/>
+  </pattern>
+  <linearGradient id="lchrome" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#6d716f"/>
+    <stop offset="0.28" stop-color="#e8ebe9"/>
+    <stop offset="0.5" stop-color="#9ba09d"/>
+    <stop offset="0.72" stop-color="#fafbfa"/>
+    <stop offset="1" stop-color="#767b78"/>
+  </linearGradient>
+  <linearGradient id="lpanel" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#172018"/>
+    <stop offset="1" stop-color="#0f1510"/>
+  </linearGradient>
+  <linearGradient id="lpanelLive" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#202c23"/>
+    <stop offset="1" stop-color="#141c16"/>
+  </linearGradient>
+  <marker id="la" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+    <path d="M0,0 L10,5 L0,10 z" fill="#949a96"/>
+  </marker>
+</defs>
+
+<rect x="0" y="0" width="980" height="1300" fill="url(#lbg)"/>
+<rect x="0" y="0" width="980" height="1300" fill="url(#lgrid)"/>
+
+<text x="34" y="46" fill="#6faa85" font-size="15" font-weight="700" letter-spacing="3.4" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">LOW LEVEL DESIGN</text>
+<text x="34" y="88" fill="#f2f5f3" font-size="34" font-weight="700">Drone and server</text>
+<text x="34" y="118" fill="#939a95" font-size="19">The full designed system. None of this band exists in src/ today.</text>
+<rect x="700" y="30" width="1" height="62" fill="#333d36"/>
+<text x="946" y="52" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">25 ms tick budget</text>
+<text x="946" y="78" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Q1 64 / Q2 64 / Q3 128</text>
+
+<text x="34" y="164" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
+<text x="68" y="164" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">ON DRONE</text>
+<text x="216" y="164" fill="#757c77" font-size="18">actors with bounded queues between every stage</text>
+<line x1="34" y1="178" x2="946" y2="178" stroke="#222c25" stroke-width="1"/>
+
+<rect x="34" y="194" width="912" height="62" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="56" y="222" fill="#ecefed" font-size="20" font-weight="700">Root Supervisor</text>
+<text x="56" y="246" fill="#a5aca7" font-size="17">restarts crashed agents, enforces deadlines, GPS and PTP time sync</text>
+<text x="924" y="234" fill="#838a85" font-size="16" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">health beacon 200 ms</text>
+
+<rect x="34" y="272" width="912" height="62" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="56" y="300" fill="#ecefed" font-size="20" font-weight="700">Ingestion actors</text>
+<text x="56" y="324" fill="#a5aca7" font-size="17">one per bus: IMU, GPS, LiDAR, camera. Emits Frame{seq, ts, payload}</text>
+<text x="924" y="312" fill="#838a85" font-size="16" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Q1 bounded 64 / 5 ms</text>
+
+<path d="M 490 334 L 490 348" stroke="#949a96" stroke-width="1.8" fill="none" marker-end="url(#la)"/>
+
+<rect x="34" y="356" width="912" height="62" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="56" y="384" fill="#ecefed" font-size="20" font-weight="700">Preprocess pipeline</text>
+<text x="56" y="408" fill="#a5aca7" font-size="17">calibrate, filter, fuse, deterministic. Emits Features[list[float]]</text>
+<text x="924" y="396" fill="#838a85" font-size="16" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Q2 bounded 64 / 8 ms</text>
+
+<path d="M 490 418 L 490 432" stroke="#949a96" stroke-width="1.8" fill="none" marker-end="url(#la)"/>
+
+<rect x="34" y="440" width="912" height="62" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="56" y="468" fill="#ecefed" font-size="20" font-weight="700">Policy service</text>
+<text x="56" y="492" fill="#a5aca7" font-size="17">candidate generator plus alignment scorer, weighted by the constitution</text>
+<text x="924" y="480" fill="#838a85" font-size="16" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Q3 bounded 128 / 7 ms</text>
+
+<path d="M 490 502 L 490 516" stroke="#949a96" stroke-width="1.8" fill="none" marker-end="url(#la)"/>
+
+<rect x="34" y="524" width="912" height="66" fill="url(#lpanelLive)" stroke="url(#lchrome)" stroke-width="2.2"/>
+<text x="56" y="552" fill="#ffffff" font-size="20" font-weight="700">Safety Controller</text>
+<text x="56" y="578" fill="#ccd2ce" font-size="17">geofence, separation, altitude, return to home. Final arbiter, overrides any action</text>
+<text x="924" y="564" fill="#a5aca7" font-size="16" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 ms</text>
+
+<rect x="34" y="606" width="912" height="56" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="56" y="632" fill="#ecefed" font-size="20" font-weight="700">Black Box</text>
+<text x="56" y="654" fill="#a5aca7" font-size="17">ring buffer of agent logs, decisions and overrides for the last N minutes</text>
+
+<text x="34" y="710" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">02</text>
+<text x="68" y="710" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">INTERFACES</text>
+<text x="232" y="710" fill="#757c77" font-size="18">data plane stays internal, control plane is externalised</text>
+<line x1="34" y1="724" x2="946" y2="724" stroke="#222c25" stroke-width="1"/>
+
+<rect x="34" y="740" width="440" height="150" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="56" y="770" fill="#ecefed" font-size="20" font-weight="700">gRPC, data plane</text>
+<text x="56" y="798" fill="#a5aca7" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AppendEvents(stream) -> Ack</text>
+<text x="56" y="822" fill="#a5aca7" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">HealthBeat(HealthMsg) -> Ack</text>
+<text x="56" y="846" fill="#a5aca7" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Decide(stream Observation)</text>
+<text x="56" y="874" fill="#838a85" font-size="16">mTLS, deadlines 50 to 100 ms, idempotent on (drone_id, seq)</text>
+
+<rect x="506" y="740" width="440" height="150" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="528" y="770" fill="#ecefed" font-size="20" font-weight="700">REST, control plane</text>
+<text x="528" y="798" fill="#a5aca7" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">GET  /v1/constitution</text>
+<text x="528" y="822" fill="#a5aca7" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">POST /v1/override</text>
+<text x="528" y="846" fill="#a5aca7" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">GET  /v1/flags</text>
+<text x="528" y="874" fill="#838a85" font-size="16">signed configs, ETag cached 5 to 15 min, 5 percent cohorts</text>
+
+<text x="34" y="938" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">03</text>
+<text x="68" y="938" fill="#c8cec9" font-size="17" font-weight="700" letter-spacing="2.2">SERVER</text>
+<text x="184" y="938" fill="#757c77" font-size="18">append only event store, and the loop that re-weights the constitution</text>
+<line x1="34" y1="952" x2="946" y2="952" stroke="#222c25" stroke-width="1"/>
+
+<rect x="34" y="968" width="440" height="70" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="56" y="996" fill="#ecefed" font-size="19" font-weight="700">gRPC Ingest Gateway</text>
+<text x="56" y="1022" fill="#a5aca7" font-size="16.5">mTLS, rate limited per drone</text>
+
+<rect x="506" y="968" width="440" height="70" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="528" y="996" fill="#ecefed" font-size="19" font-weight="700">Stream Processor</text>
+<text x="528" y="1022" fill="#a5aca7" font-size="16.5">windowed enrich into event store and time series</text>
+
+<rect x="34" y="1052" width="440" height="70" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="56" y="1080" fill="#ecefed" font-size="19" font-weight="700">Analytics and Evals</text>
+<text x="56" y="1106" fill="#a5aca7" font-size="16.5">p50 and p95 latency, intervention rate, drift</text>
+
+<rect x="506" y="1052" width="440" height="70" fill="url(#lpanelLive)" stroke="url(#lchrome)" stroke-width="2.2"/>
+<text x="528" y="1080" fill="#ffffff" font-size="19" font-weight="700">Weight Learner</text>
+<text x="528" y="1106" fill="#ccd2ce" font-size="16.5">re-weights the constitution on long horizon outcomes</text>
+
+<rect x="34" y="1136" width="440" height="70" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="56" y="1164" fill="#ecefed" font-size="19" font-weight="700">Config and Weights API</text>
+<text x="56" y="1190" fill="#a5aca7" font-size="16.5">serves weights.json, canary rollout, auto rollback</text>
+
+<rect x="506" y="1136" width="440" height="70" fill="url(#lpanel)" stroke="#47514a" stroke-width="1.5"/>
+<text x="528" y="1164" fill="#ecefed" font-size="19" font-weight="700">Monitoring and Alerts</text>
+<text x="528" y="1190" fill="#a5aca7" font-size="16.5">SLOs, pager on error budget burn</text>
+
+<line x1="34" y1="1240" x2="946" y2="1240" stroke="#222c25" stroke-width="1"/>
+<text x="34" y="1272" fill="#838a85" font-size="17">Degrade path: repeated agent crashes quarantine the policy down to a simpler heuristic; a dead config</text>
+<text x="34" y="1294" fill="#838a85" font-size="17">service holds the last weights until TTL, then falls back to the safest default.</text>
+</svg>

--- a/assets/reward-shaping.svg
+++ b/assets/reward-shaping.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 780" width="980" height="780" role="img" aria-label="Reward shaping on two axes: self alignment against peer interaction, each either event based or continuous, giving four quadrants of which continuous on both axes is the most stable" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="bg2" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#12161d"/>
+    <stop offset="1" stop-color="#0a0d12"/>
+  </linearGradient>
+  <linearGradient id="chrome2" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#8d99a8"/>
+    <stop offset="0.35" stop-color="#e6edf5"/>
+    <stop offset="0.62" stop-color="#9aa6b5"/>
+    <stop offset="1" stop-color="#dfe7f0"/>
+  </linearGradient>
+  <linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#1e242e"/>
+    <stop offset="1" stop-color="#151a22"/>
+  </linearGradient>
+  <linearGradient id="cellBest" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#28303c"/>
+    <stop offset="1" stop-color="#1b212a"/>
+  </linearGradient>
+</defs>
+
+<rect x="0" y="0" width="980" height="780" rx="12" fill="url(#bg2)"/>
+
+<text x="34" y="52" fill="#f2f6fa" font-size="27" font-weight="700">Reward shaping, two axes</text>
+<text x="34" y="79" fill="#93a1b3" font-size="15.5">A spiky reward invites goal hacking. A continuous one prices the behaviour you actually want.</text>
+<text x="946" y="52" fill="#8f9dae" font-size="14.5" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">design reference,</text>
+<text x="946" y="76" fill="#8f9dae" font-size="14.5" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">not yet implemented</text>
+
+<line x1="34" y1="102" x2="946" y2="102" stroke="#2b333f" stroke-width="1"/>
+
+<text x="118" y="136" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6">PEER INTERACTION</text>
+<text x="318" y="170" fill="#aab6c6" font-size="15.5" font-weight="700" text-anchor="middle">event based</text>
+<text x="318" y="190" fill="#6f7c8d" font-size="14" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+Y if coop_event else 0</text>
+<text x="746" y="170" fill="#aab6c6" font-size="15.5" font-weight="700" text-anchor="middle">continuous</text>
+<text x="746" y="190" fill="#6f7c8d" font-size="14" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">g(coop_quality)</text>
+
+<text x="0" y="0" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6" text-anchor="middle" transform="translate(28,470) rotate(-90)">SELF ALIGNMENT</text>
+<text x="0" y="0" fill="#aab6c6" font-size="15.5" font-weight="700" text-anchor="middle" transform="translate(62,333) rotate(-90)">event based</text>
+<text x="0" y="0" fill="#6f7c8d" font-size="13.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,333) rotate(-90)">+X if goal_met else 0</text>
+<text x="0" y="0" fill="#aab6c6" font-size="15.5" font-weight="700" text-anchor="middle" transform="translate(62,613) rotate(-90)">continuous</text>
+<text x="0" y="0" fill="#6f7c8d" font-size="13.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,613) rotate(-90)">f(alignment_score)</text>
+
+<rect x="118" y="204" width="400" height="258" rx="9" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
+<text x="140" y="240" fill="#e9eff6" font-size="18" font-weight="700">Spiky on both axes</text>
+<text x="140" y="266" fill="#9dabbc" font-size="15.5">Unstable. Goal hacking is likely,</text>
+<text x="140" y="288" fill="#9dabbc" font-size="15.5">because only the spike is paid.</text>
+<line x1="140" y1="308" x2="496" y2="308" stroke="#2b333f" stroke-width="1"/>
+<text x="140" y="334" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
+<text x="140" y="356" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
+<text x="140" y="392" fill="#c3cedd" font-size="15">The drone ignores battery and sensor</text>
+<text x="140" y="414" fill="#c3cedd" font-size="15">health to finish the route, and yields to</text>
+<text x="140" y="436" fill="#c3cedd" font-size="15">peers only when forced at a choke point.</text>
+
+<rect x="546" y="204" width="400" height="258" rx="9" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
+<text x="568" y="240" fill="#e9eff6" font-size="18" font-weight="700">Spiky on self only</text>
+<text x="568" y="266" fill="#9dabbc" font-size="15.5">Cooperation looks excellent while</text>
+<text x="568" y="288" fill="#9dabbc" font-size="15.5">solo navigation quietly degrades.</text>
+<line x1="568" y1="308" x2="924" y2="308" stroke="#2b333f" stroke-width="1"/>
+<text x="568" y="334" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
+<text x="568" y="356" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
+<text x="568" y="392" fill="#c3cedd" font-size="15">The drone skips its safety checks to</text>
+<text x="568" y="414" fill="#c3cedd" font-size="15">finish the mission, yet holds perfect</text>
+<text x="568" y="436" fill="#c3cedd" font-size="15">formation with its peers throughout.</text>
+
+<rect x="118" y="484" width="400" height="258" rx="9" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
+<text x="140" y="520" fill="#e9eff6" font-size="18" font-weight="700">Spiky on peers only</text>
+<text x="140" y="546" fill="#9dabbc" font-size="15.5">Flies itself well, but competes</text>
+<text x="140" y="568" fill="#9dabbc" font-size="15.5">whenever cooperation is not scored.</text>
+<line x1="140" y1="588" x2="496" y2="588" stroke="#2b333f" stroke-width="1"/>
+<text x="140" y="614" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
+<text x="140" y="636" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
+<text x="140" y="672" fill="#c3cedd" font-size="15">The drone flies safely and efficiently,</text>
+<text x="140" y="694" fill="#c3cedd" font-size="15">but will cut in front of a peer to reach</text>
+<text x="140" y="716" fill="#c3cedd" font-size="15">the drop zone first.</text>
+
+<rect x="546" y="484" width="400" height="258" rx="9" fill="url(#cellBest)" stroke="url(#chrome2)" stroke-width="2.6"/>
+<text x="568" y="520" fill="#ffffff" font-size="18" font-weight="700">Continuous on both axes</text>
+<text x="568" y="546" fill="#c3cedd" font-size="15.5">The stable quadrant. Every second is</text>
+<text x="568" y="568" fill="#c3cedd" font-size="15.5">priced, so there is no spike to chase.</text>
+<line x1="568" y1="588" x2="924" y2="588" stroke="#4d5867" stroke-width="1"/>
+<text x="568" y="614" fill="#aab6c6" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
+<text x="568" y="636" fill="#aab6c6" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
+<text x="568" y="672" fill="#dfe7f0" font-size="15">The drone stays inside its safety margins</text>
+<text x="568" y="694" fill="#dfe7f0" font-size="15">and holds smooth coordination with its</text>
+<text x="568" y="716" fill="#dfe7f0" font-size="15">peers, continuously.</text>
+</svg>

--- a/assets/reward-shaping.svg
+++ b/assets/reward-shaping.svg
@@ -22,66 +22,65 @@
 
 <rect x="0" y="0" width="980" height="780" rx="12" fill="url(#bg2)"/>
 
-<text x="34" y="52" fill="#f2f6fa" font-size="27" font-weight="700">Reward shaping, two axes</text>
-<text x="34" y="79" fill="#93a1b3" font-size="15.5">A spiky reward invites goal hacking. A continuous one prices the behaviour you actually want.</text>
-<text x="946" y="52" fill="#8f9dae" font-size="14.5" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">design reference,</text>
-<text x="946" y="76" fill="#8f9dae" font-size="14.5" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">not yet implemented</text>
+<text x="34" y="52" fill="#f2f6fa" font-size="31" font-weight="700">Reward shaping, two axes</text>
+<text x="34" y="79" fill="#93a1b3" font-size="18">A spiky reward invites goal hacking. A continuous one prices the behaviour you actually want.</text>
 
 <line x1="34" y1="102" x2="946" y2="102" stroke="#2b333f" stroke-width="1"/>
 
-<text x="118" y="136" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6">PEER INTERACTION</text>
-<text x="318" y="170" fill="#aab6c6" font-size="15.5" font-weight="700" text-anchor="middle">event based</text>
-<text x="318" y="190" fill="#6f7c8d" font-size="14" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+Y if coop_event else 0</text>
-<text x="746" y="170" fill="#aab6c6" font-size="15.5" font-weight="700" text-anchor="middle">continuous</text>
-<text x="746" y="190" fill="#6f7c8d" font-size="14" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">g(coop_quality)</text>
+<text x="118" y="136" fill="#7e8b9c" font-size="16" font-weight="700" letter-spacing="1.6">PEER INTERACTION</text>
+<text x="318" y="170" fill="#aab6c6" font-size="21" font-weight="700" text-anchor="middle">event based</text>
+<text x="318" y="190" fill="#6f7c8d" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+Y if coop_event else 0</text>
+<text x="746" y="170" fill="#aab6c6" font-size="21" font-weight="700" text-anchor="middle">continuous</text>
+<text x="746" y="190" fill="#6f7c8d" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">g(coop_quality)</text>
 
-<text x="0" y="0" fill="#7e8b9c" font-size="14" font-weight="700" letter-spacing="1.6" text-anchor="middle" transform="translate(28,470) rotate(-90)">SELF ALIGNMENT</text>
-<text x="0" y="0" fill="#aab6c6" font-size="15.5" font-weight="700" text-anchor="middle" transform="translate(62,333) rotate(-90)">event based</text>
-<text x="0" y="0" fill="#6f7c8d" font-size="13.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,333) rotate(-90)">+X if goal_met else 0</text>
-<text x="0" y="0" fill="#aab6c6" font-size="15.5" font-weight="700" text-anchor="middle" transform="translate(62,613) rotate(-90)">continuous</text>
-<text x="0" y="0" fill="#6f7c8d" font-size="13.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,613) rotate(-90)">f(alignment_score)</text>
+<text x="0" y="0" fill="#7e8b9c" font-size="16" font-weight="700" letter-spacing="1.6" text-anchor="middle" transform="translate(28,470) rotate(-90)">SELF ALIGNMENT</text>
+<text x="0" y="0" fill="#aab6c6" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,333) rotate(-90)">event based</text>
+<text x="0" y="0" fill="#6f7c8d" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,333) rotate(-90)">+X if goal_met else 0</text>
+<text x="0" y="0" fill="#aab6c6" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,613) rotate(-90)">continuous</text>
+<text x="0" y="0" fill="#6f7c8d" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,613) rotate(-90)">f(alignment_score)</text>
 
 <rect x="118" y="204" width="400" height="258" rx="9" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
-<text x="140" y="240" fill="#e9eff6" font-size="18" font-weight="700">Spiky on both axes</text>
-<text x="140" y="266" fill="#9dabbc" font-size="15.5">Unstable. Goal hacking is likely,</text>
-<text x="140" y="288" fill="#9dabbc" font-size="15.5">because only the spike is paid.</text>
+<text x="140" y="240" fill="#e9eff6" font-size="21" font-weight="700">Spiky on both axes</text>
+<text x="140" y="266" fill="#9dabbc" font-size="18">Unstable. Goal hacking is likely,</text>
+<text x="140" y="288" fill="#9dabbc" font-size="18">because only the spike is paid.</text>
 <line x1="140" y1="308" x2="496" y2="308" stroke="#2b333f" stroke-width="1"/>
-<text x="140" y="334" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
-<text x="140" y="356" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
-<text x="140" y="392" fill="#c3cedd" font-size="15">The drone ignores battery and sensor</text>
-<text x="140" y="414" fill="#c3cedd" font-size="15">health to finish the route, and yields to</text>
-<text x="140" y="436" fill="#c3cedd" font-size="15">peers only when forced at a choke point.</text>
+<text x="140" y="334" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
+<text x="140" y="356" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
+<text x="140" y="392" fill="#c3cedd" font-size="17.5">The drone ignores battery and sensor</text>
+<text x="140" y="414" fill="#c3cedd" font-size="17.5">health to finish the route, and yields to</text>
+<text x="140" y="436" fill="#c3cedd" font-size="17.5">peers only when forced at a choke point.</text>
 
 <rect x="546" y="204" width="400" height="258" rx="9" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
-<text x="568" y="240" fill="#e9eff6" font-size="18" font-weight="700">Spiky on self only</text>
-<text x="568" y="266" fill="#9dabbc" font-size="15.5">Cooperation looks excellent while</text>
-<text x="568" y="288" fill="#9dabbc" font-size="15.5">solo navigation quietly degrades.</text>
+<text x="568" y="240" fill="#e9eff6" font-size="21" font-weight="700">Spiky on self only</text>
+<text x="568" y="266" fill="#9dabbc" font-size="18">Cooperation looks excellent while</text>
+<text x="568" y="288" fill="#9dabbc" font-size="18">solo navigation quietly degrades.</text>
 <line x1="568" y1="308" x2="924" y2="308" stroke="#2b333f" stroke-width="1"/>
-<text x="568" y="334" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
-<text x="568" y="356" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
-<text x="568" y="392" fill="#c3cedd" font-size="15">The drone skips its safety checks to</text>
-<text x="568" y="414" fill="#c3cedd" font-size="15">finish the mission, yet holds perfect</text>
-<text x="568" y="436" fill="#c3cedd" font-size="15">formation with its peers throughout.</text>
+<text x="568" y="334" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
+<text x="568" y="356" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
+<text x="568" y="392" fill="#c3cedd" font-size="17.5">The drone skips its safety checks to</text>
+<text x="568" y="414" fill="#c3cedd" font-size="17.5">finish the mission, yet holds perfect</text>
+<text x="568" y="436" fill="#c3cedd" font-size="17.5">formation with its peers throughout.</text>
 
 <rect x="118" y="484" width="400" height="258" rx="9" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
-<text x="140" y="520" fill="#e9eff6" font-size="18" font-weight="700">Spiky on peers only</text>
-<text x="140" y="546" fill="#9dabbc" font-size="15.5">Flies itself well, but competes</text>
-<text x="140" y="568" fill="#9dabbc" font-size="15.5">whenever cooperation is not scored.</text>
+<text x="140" y="520" fill="#e9eff6" font-size="21" font-weight="700">Spiky on peers only</text>
+<text x="140" y="546" fill="#9dabbc" font-size="18">Flies itself well, but competes</text>
+<text x="140" y="568" fill="#9dabbc" font-size="18">whenever cooperation is not scored.</text>
 <line x1="140" y1="588" x2="496" y2="588" stroke="#2b333f" stroke-width="1"/>
-<text x="140" y="614" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
-<text x="140" y="636" fill="#8f9dae" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
-<text x="140" y="672" fill="#c3cedd" font-size="15">The drone flies safely and efficiently,</text>
-<text x="140" y="694" fill="#c3cedd" font-size="15">but will cut in front of a peer to reach</text>
-<text x="140" y="716" fill="#c3cedd" font-size="15">the drop zone first.</text>
+<text x="140" y="614" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
+<text x="140" y="636" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
+<text x="140" y="672" fill="#c3cedd" font-size="17.5">The drone flies safely and efficiently,</text>
+<text x="140" y="694" fill="#c3cedd" font-size="17.5">but will cut in front of a peer to reach</text>
+<text x="140" y="716" fill="#c3cedd" font-size="17.5">the drop zone first.</text>
 
 <rect x="546" y="484" width="400" height="258" rx="9" fill="url(#cellBest)" stroke="url(#chrome2)" stroke-width="2.6"/>
-<text x="568" y="520" fill="#ffffff" font-size="18" font-weight="700">Continuous on both axes</text>
-<text x="568" y="546" fill="#c3cedd" font-size="15.5">The stable quadrant. Every second is</text>
-<text x="568" y="568" fill="#c3cedd" font-size="15.5">priced, so there is no spike to chase.</text>
+<text x="568" y="520" fill="#ffffff" font-size="21" font-weight="700">Continuous on both axes</text>
+<text x="568" y="546" fill="#c3cedd" font-size="18">The stable quadrant. Every second is</text>
+<text x="568" y="568" fill="#c3cedd" font-size="18">priced, so there is no spike to chase.</text>
 <line x1="568" y1="588" x2="924" y2="588" stroke="#4d5867" stroke-width="1"/>
-<text x="568" y="614" fill="#aab6c6" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
-<text x="568" y="636" fill="#aab6c6" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
-<text x="568" y="672" fill="#dfe7f0" font-size="15">The drone stays inside its safety margins</text>
-<text x="568" y="694" fill="#dfe7f0" font-size="15">and holds smooth coordination with its</text>
-<text x="568" y="716" fill="#dfe7f0" font-size="15">peers, continuously.</text>
+<text x="568" y="614" fill="#aab6c6" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
+<text x="568" y="636" fill="#aab6c6" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
+<text x="568" y="672" fill="#dfe7f0" font-size="17.5">The drone stays inside its safety margins</text>
+<text x="568" y="694" fill="#dfe7f0" font-size="17.5">and holds smooth coordination with its</text>
+<text x="568" y="716" fill="#dfe7f0" font-size="17.5">peers, continuously.</text>
+<text x="118" y="770" fill="#6f7c8d" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">design reference for the multi-drone roadmap; not implemented in src/ today</text>
 </svg>

--- a/assets/reward-shaping.svg
+++ b/assets/reward-shaping.svg
@@ -2,85 +2,85 @@
 <defs>
   <linearGradient id="bg2" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0" stop-color="#0d1410"/>
-    <stop offset="1" stop-color="#070b08"/>
+    <stop offset="1" stop-color="#040705"/>
   </linearGradient>
   <linearGradient id="chrome2" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#8f9491"/>
+    <stop offset="0" stop-color="#7a7f7c"/>
     <stop offset="0.35" stop-color="#e6e9e7"/>
-    <stop offset="0.62" stop-color="#9ea3a0"/>
+    <stop offset="0.62" stop-color="#888d8a"/>
     <stop offset="1" stop-color="#dfe3e0"/>
   </linearGradient>
   <linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#182119"/>
-    <stop offset="1" stop-color="#131a14"/>
+    <stop offset="0" stop-color="#10160f"/>
+    <stop offset="1" stop-color="#0d120e"/>
   </linearGradient>
   <linearGradient id="cellBest" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#212d24"/>
-    <stop offset="1" stop-color="#141c16"/>
+    <stop offset="0" stop-color="#18211a"/>
+    <stop offset="1" stop-color="#0d120e"/>
   </linearGradient>
 </defs>
 
 <rect x="0" y="0" width="980" height="780" fill="url(#bg2)"/>
 
 <text x="34" y="52" fill="#f2f5f3" font-size="31" font-weight="700">Reward shaping, two axes</text>
-<text x="34" y="79" fill="#979e99" font-size="18">A spiky reward invites goal hacking. A continuous one prices the behaviour you actually want.</text>
+<text x="34" y="79" fill="#8b928d" font-size="18">A spiky reward invites goal hacking. A continuous one prices the behaviour you actually want.</text>
 
-<line x1="34" y1="102" x2="946" y2="102" stroke="#333d36" stroke-width="1"/>
+<line x1="34" y1="102" x2="946" y2="102" stroke="#232b25" stroke-width="1"/>
 
-<text x="118" y="136" fill="#828983" font-size="16" font-weight="700" letter-spacing="1.6">PEER INTERACTION</text>
-<text x="318" y="170" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle">event based</text>
-<text x="318" y="190" fill="#757c77" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+Y if coop_event else 0</text>
-<text x="746" y="170" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle">continuous</text>
-<text x="746" y="190" fill="#757c77" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">g(coop_quality)</text>
+<text x="118" y="136" fill="#787f7a" font-size="16" font-weight="700" letter-spacing="1.6">PEER INTERACTION</text>
+<text x="318" y="170" fill="#9aa19c" font-size="21" font-weight="700" text-anchor="middle">event based</text>
+<text x="318" y="190" fill="#6b726d" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+Y if coop_event else 0</text>
+<text x="746" y="170" fill="#9aa19c" font-size="21" font-weight="700" text-anchor="middle">continuous</text>
+<text x="746" y="190" fill="#6b726d" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">g(coop_quality)</text>
 
-<text x="0" y="0" fill="#828983" font-size="16" font-weight="700" letter-spacing="1.6" text-anchor="middle" transform="translate(28,470) rotate(-90)">SELF ALIGNMENT</text>
-<text x="0" y="0" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,333) rotate(-90)">event based</text>
-<text x="0" y="0" fill="#757c77" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,333) rotate(-90)">+X if goal_met else 0</text>
-<text x="0" y="0" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,613) rotate(-90)">continuous</text>
-<text x="0" y="0" fill="#757c77" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,613) rotate(-90)">f(alignment_score)</text>
+<text x="0" y="0" fill="#787f7a" font-size="16" font-weight="700" letter-spacing="1.6" text-anchor="middle" transform="translate(28,470) rotate(-90)">SELF ALIGNMENT</text>
+<text x="0" y="0" fill="#9aa19c" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,333) rotate(-90)">event based</text>
+<text x="0" y="0" fill="#6b726d" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,333) rotate(-90)">+X if goal_met else 0</text>
+<text x="0" y="0" fill="#9aa19c" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,613) rotate(-90)">continuous</text>
+<text x="0" y="0" fill="#6b726d" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,613) rotate(-90)">f(alignment_score)</text>
 
-<rect x="118" y="204" width="400" height="258" fill="url(#cell)" stroke="#4b544d" stroke-width="1.6"/>
+<rect x="118" y="204" width="400" height="258" fill="url(#cell)" stroke="#2e3830" stroke-width="1.6"/>
 <text x="140" y="240" fill="#eaedeb" font-size="21" font-weight="700">Spiky on both axes</text>
-<text x="140" y="266" fill="#a3aaa5" font-size="18">Unstable. Goal hacking is likely,</text>
-<text x="140" y="288" fill="#a3aaa5" font-size="18">because only the spike is paid.</text>
-<line x1="140" y1="308" x2="496" y2="308" stroke="#333d36" stroke-width="1"/>
-<text x="140" y="334" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
-<text x="140" y="356" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
-<text x="140" y="392" fill="#c9cfcb" font-size="17.5">The drone ignores battery and sensor</text>
-<text x="140" y="414" fill="#c9cfcb" font-size="17.5">health to finish the route, and yields to</text>
-<text x="140" y="436" fill="#c9cfcb" font-size="17.5">peers only when forced at a choke point.</text>
+<text x="140" y="266" fill="#9aa19c" font-size="18">Unstable. Goal hacking is likely,</text>
+<text x="140" y="288" fill="#9aa19c" font-size="18">because only the spike is paid.</text>
+<line x1="140" y1="308" x2="496" y2="308" stroke="#232b25" stroke-width="1"/>
+<text x="140" y="334" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
+<text x="140" y="356" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
+<text x="140" y="392" fill="#c4cac5" font-size="17.5">The drone ignores battery and sensor</text>
+<text x="140" y="414" fill="#c4cac5" font-size="17.5">health to finish the route, and yields to</text>
+<text x="140" y="436" fill="#c4cac5" font-size="17.5">peers only when forced at a choke point.</text>
 
-<rect x="546" y="204" width="400" height="258" fill="url(#cell)" stroke="#4b544d" stroke-width="1.6"/>
+<rect x="546" y="204" width="400" height="258" fill="url(#cell)" stroke="#2e3830" stroke-width="1.6"/>
 <text x="568" y="240" fill="#eaedeb" font-size="21" font-weight="700">Spiky on self only</text>
-<text x="568" y="266" fill="#a3aaa5" font-size="18">Cooperation looks excellent while</text>
-<text x="568" y="288" fill="#a3aaa5" font-size="18">solo navigation quietly degrades.</text>
-<line x1="568" y1="308" x2="924" y2="308" stroke="#333d36" stroke-width="1"/>
-<text x="568" y="334" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
-<text x="568" y="356" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
-<text x="568" y="392" fill="#c9cfcb" font-size="17.5">The drone skips its safety checks to</text>
-<text x="568" y="414" fill="#c9cfcb" font-size="17.5">finish the mission, yet holds perfect</text>
-<text x="568" y="436" fill="#c9cfcb" font-size="17.5">formation with its peers throughout.</text>
+<text x="568" y="266" fill="#9aa19c" font-size="18">Cooperation looks excellent while</text>
+<text x="568" y="288" fill="#9aa19c" font-size="18">solo navigation quietly degrades.</text>
+<line x1="568" y1="308" x2="924" y2="308" stroke="#232b25" stroke-width="1"/>
+<text x="568" y="334" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
+<text x="568" y="356" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
+<text x="568" y="392" fill="#c4cac5" font-size="17.5">The drone skips its safety checks to</text>
+<text x="568" y="414" fill="#c4cac5" font-size="17.5">finish the mission, yet holds perfect</text>
+<text x="568" y="436" fill="#c4cac5" font-size="17.5">formation with its peers throughout.</text>
 
-<rect x="118" y="484" width="400" height="258" fill="url(#cell)" stroke="#4b544d" stroke-width="1.6"/>
+<rect x="118" y="484" width="400" height="258" fill="url(#cell)" stroke="#2e3830" stroke-width="1.6"/>
 <text x="140" y="520" fill="#eaedeb" font-size="21" font-weight="700">Spiky on peers only</text>
-<text x="140" y="546" fill="#a3aaa5" font-size="18">Flies itself well, but competes</text>
-<text x="140" y="568" fill="#a3aaa5" font-size="18">whenever cooperation is not scored.</text>
-<line x1="140" y1="588" x2="496" y2="588" stroke="#333d36" stroke-width="1"/>
-<text x="140" y="614" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
-<text x="140" y="636" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
-<text x="140" y="672" fill="#c9cfcb" font-size="17.5">The drone flies safely and efficiently,</text>
-<text x="140" y="694" fill="#c9cfcb" font-size="17.5">but will cut in front of a peer to reach</text>
-<text x="140" y="716" fill="#c9cfcb" font-size="17.5">the drop zone first.</text>
+<text x="140" y="546" fill="#9aa19c" font-size="18">Flies itself well, but competes</text>
+<text x="140" y="568" fill="#9aa19c" font-size="18">whenever cooperation is not scored.</text>
+<line x1="140" y1="588" x2="496" y2="588" stroke="#232b25" stroke-width="1"/>
+<text x="140" y="614" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
+<text x="140" y="636" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
+<text x="140" y="672" fill="#c4cac5" font-size="17.5">The drone flies safely and efficiently,</text>
+<text x="140" y="694" fill="#c4cac5" font-size="17.5">but will cut in front of a peer to reach</text>
+<text x="140" y="716" fill="#c4cac5" font-size="17.5">the drop zone first.</text>
 
 <rect x="546" y="484" width="400" height="258" fill="url(#cellBest)" stroke="url(#chrome2)" stroke-width="2.6"/>
 <text x="568" y="520" fill="#ffffff" font-size="21" font-weight="700">Continuous on both axes</text>
-<text x="568" y="546" fill="#c9cfcb" font-size="18">The stable quadrant. Every second is</text>
-<text x="568" y="568" fill="#c9cfcb" font-size="18">priced, so there is no spike to chase.</text>
-<line x1="568" y1="588" x2="924" y2="588" stroke="#525b54" stroke-width="1"/>
-<text x="568" y="614" fill="#a9afab" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
-<text x="568" y="636" fill="#a9afab" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
+<text x="568" y="546" fill="#c4cac5" font-size="18">The stable quadrant. Every second is</text>
+<text x="568" y="568" fill="#c4cac5" font-size="18">priced, so there is no spike to chase.</text>
+<line x1="568" y1="588" x2="924" y2="588" stroke="#37423a" stroke-width="1"/>
+<text x="568" y="614" fill="#9aa19c" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
+<text x="568" y="636" fill="#9aa19c" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
 <text x="568" y="672" fill="#dfe3e0" font-size="17.5">The drone stays inside its safety margins</text>
 <text x="568" y="694" fill="#dfe3e0" font-size="17.5">and holds smooth coordination with its</text>
 <text x="568" y="716" fill="#dfe3e0" font-size="17.5">peers, continuously.</text>
-<text x="118" y="770" fill="#757c77" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">design reference for the multi-drone roadmap; not implemented in src/ today</text>
+<text x="118" y="770" fill="#6b726d" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">design reference for the multi-drone roadmap; not implemented in src/ today</text>
 </svg>

--- a/assets/reward-shaping.svg
+++ b/assets/reward-shaping.svg
@@ -1,86 +1,86 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 780" width="980" height="780" role="img" aria-label="Reward shaping on two axes: self alignment against peer interaction, each either event based or continuous, giving four quadrants of which continuous on both axes is the most stable" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
 <defs>
   <linearGradient id="bg2" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#12161d"/>
-    <stop offset="1" stop-color="#0a0d12"/>
+    <stop offset="0" stop-color="#0d1410"/>
+    <stop offset="1" stop-color="#070b08"/>
   </linearGradient>
   <linearGradient id="chrome2" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#8d99a8"/>
-    <stop offset="0.35" stop-color="#e6edf5"/>
-    <stop offset="0.62" stop-color="#9aa6b5"/>
-    <stop offset="1" stop-color="#dfe7f0"/>
+    <stop offset="0" stop-color="#8f9491"/>
+    <stop offset="0.35" stop-color="#e6e9e7"/>
+    <stop offset="0.62" stop-color="#9ea3a0"/>
+    <stop offset="1" stop-color="#dfe3e0"/>
   </linearGradient>
   <linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#1e242e"/>
-    <stop offset="1" stop-color="#151a22"/>
+    <stop offset="0" stop-color="#182119"/>
+    <stop offset="1" stop-color="#131a14"/>
   </linearGradient>
   <linearGradient id="cellBest" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#28303c"/>
-    <stop offset="1" stop-color="#1b212a"/>
+    <stop offset="0" stop-color="#212d24"/>
+    <stop offset="1" stop-color="#141c16"/>
   </linearGradient>
 </defs>
 
 <rect x="0" y="0" width="980" height="780" fill="url(#bg2)"/>
 
-<text x="34" y="52" fill="#f2f6fa" font-size="31" font-weight="700">Reward shaping, two axes</text>
-<text x="34" y="79" fill="#93a1b3" font-size="18">A spiky reward invites goal hacking. A continuous one prices the behaviour you actually want.</text>
+<text x="34" y="52" fill="#f2f5f3" font-size="31" font-weight="700">Reward shaping, two axes</text>
+<text x="34" y="79" fill="#979e99" font-size="18">A spiky reward invites goal hacking. A continuous one prices the behaviour you actually want.</text>
 
-<line x1="34" y1="102" x2="946" y2="102" stroke="#2b333f" stroke-width="1"/>
+<line x1="34" y1="102" x2="946" y2="102" stroke="#333d36" stroke-width="1"/>
 
-<text x="118" y="136" fill="#7e8b9c" font-size="16" font-weight="700" letter-spacing="1.6">PEER INTERACTION</text>
-<text x="318" y="170" fill="#aab6c6" font-size="21" font-weight="700" text-anchor="middle">event based</text>
-<text x="318" y="190" fill="#6f7c8d" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+Y if coop_event else 0</text>
-<text x="746" y="170" fill="#aab6c6" font-size="21" font-weight="700" text-anchor="middle">continuous</text>
-<text x="746" y="190" fill="#6f7c8d" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">g(coop_quality)</text>
+<text x="118" y="136" fill="#828983" font-size="16" font-weight="700" letter-spacing="1.6">PEER INTERACTION</text>
+<text x="318" y="170" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle">event based</text>
+<text x="318" y="190" fill="#757c77" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+Y if coop_event else 0</text>
+<text x="746" y="170" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle">continuous</text>
+<text x="746" y="190" fill="#757c77" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">g(coop_quality)</text>
 
-<text x="0" y="0" fill="#7e8b9c" font-size="16" font-weight="700" letter-spacing="1.6" text-anchor="middle" transform="translate(28,470) rotate(-90)">SELF ALIGNMENT</text>
-<text x="0" y="0" fill="#aab6c6" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,333) rotate(-90)">event based</text>
-<text x="0" y="0" fill="#6f7c8d" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,333) rotate(-90)">+X if goal_met else 0</text>
-<text x="0" y="0" fill="#aab6c6" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,613) rotate(-90)">continuous</text>
-<text x="0" y="0" fill="#6f7c8d" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,613) rotate(-90)">f(alignment_score)</text>
+<text x="0" y="0" fill="#828983" font-size="16" font-weight="700" letter-spacing="1.6" text-anchor="middle" transform="translate(28,470) rotate(-90)">SELF ALIGNMENT</text>
+<text x="0" y="0" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,333) rotate(-90)">event based</text>
+<text x="0" y="0" fill="#757c77" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,333) rotate(-90)">+X if goal_met else 0</text>
+<text x="0" y="0" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,613) rotate(-90)">continuous</text>
+<text x="0" y="0" fill="#757c77" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,613) rotate(-90)">f(alignment_score)</text>
 
-<rect x="118" y="204" width="400" height="258" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
-<text x="140" y="240" fill="#e9eff6" font-size="21" font-weight="700">Spiky on both axes</text>
-<text x="140" y="266" fill="#9dabbc" font-size="18">Unstable. Goal hacking is likely,</text>
-<text x="140" y="288" fill="#9dabbc" font-size="18">because only the spike is paid.</text>
-<line x1="140" y1="308" x2="496" y2="308" stroke="#2b333f" stroke-width="1"/>
-<text x="140" y="334" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
-<text x="140" y="356" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
-<text x="140" y="392" fill="#c3cedd" font-size="17.5">The drone ignores battery and sensor</text>
-<text x="140" y="414" fill="#c3cedd" font-size="17.5">health to finish the route, and yields to</text>
-<text x="140" y="436" fill="#c3cedd" font-size="17.5">peers only when forced at a choke point.</text>
+<rect x="118" y="204" width="400" height="258" fill="url(#cell)" stroke="#4b544d" stroke-width="1.6"/>
+<text x="140" y="240" fill="#eaedeb" font-size="21" font-weight="700">Spiky on both axes</text>
+<text x="140" y="266" fill="#a3aaa5" font-size="18">Unstable. Goal hacking is likely,</text>
+<text x="140" y="288" fill="#a3aaa5" font-size="18">because only the spike is paid.</text>
+<line x1="140" y1="308" x2="496" y2="308" stroke="#333d36" stroke-width="1"/>
+<text x="140" y="334" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
+<text x="140" y="356" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
+<text x="140" y="392" fill="#c9cfcb" font-size="17.5">The drone ignores battery and sensor</text>
+<text x="140" y="414" fill="#c9cfcb" font-size="17.5">health to finish the route, and yields to</text>
+<text x="140" y="436" fill="#c9cfcb" font-size="17.5">peers only when forced at a choke point.</text>
 
-<rect x="546" y="204" width="400" height="258" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
-<text x="568" y="240" fill="#e9eff6" font-size="21" font-weight="700">Spiky on self only</text>
-<text x="568" y="266" fill="#9dabbc" font-size="18">Cooperation looks excellent while</text>
-<text x="568" y="288" fill="#9dabbc" font-size="18">solo navigation quietly degrades.</text>
-<line x1="568" y1="308" x2="924" y2="308" stroke="#2b333f" stroke-width="1"/>
-<text x="568" y="334" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
-<text x="568" y="356" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
-<text x="568" y="392" fill="#c3cedd" font-size="17.5">The drone skips its safety checks to</text>
-<text x="568" y="414" fill="#c3cedd" font-size="17.5">finish the mission, yet holds perfect</text>
-<text x="568" y="436" fill="#c3cedd" font-size="17.5">formation with its peers throughout.</text>
+<rect x="546" y="204" width="400" height="258" fill="url(#cell)" stroke="#4b544d" stroke-width="1.6"/>
+<text x="568" y="240" fill="#eaedeb" font-size="21" font-weight="700">Spiky on self only</text>
+<text x="568" y="266" fill="#a3aaa5" font-size="18">Cooperation looks excellent while</text>
+<text x="568" y="288" fill="#a3aaa5" font-size="18">solo navigation quietly degrades.</text>
+<line x1="568" y1="308" x2="924" y2="308" stroke="#333d36" stroke-width="1"/>
+<text x="568" y="334" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
+<text x="568" y="356" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
+<text x="568" y="392" fill="#c9cfcb" font-size="17.5">The drone skips its safety checks to</text>
+<text x="568" y="414" fill="#c9cfcb" font-size="17.5">finish the mission, yet holds perfect</text>
+<text x="568" y="436" fill="#c9cfcb" font-size="17.5">formation with its peers throughout.</text>
 
-<rect x="118" y="484" width="400" height="258" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
-<text x="140" y="520" fill="#e9eff6" font-size="21" font-weight="700">Spiky on peers only</text>
-<text x="140" y="546" fill="#9dabbc" font-size="18">Flies itself well, but competes</text>
-<text x="140" y="568" fill="#9dabbc" font-size="18">whenever cooperation is not scored.</text>
-<line x1="140" y1="588" x2="496" y2="588" stroke="#2b333f" stroke-width="1"/>
-<text x="140" y="614" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
-<text x="140" y="636" fill="#8f9dae" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
-<text x="140" y="672" fill="#c3cedd" font-size="17.5">The drone flies safely and efficiently,</text>
-<text x="140" y="694" fill="#c3cedd" font-size="17.5">but will cut in front of a peer to reach</text>
-<text x="140" y="716" fill="#c3cedd" font-size="17.5">the drop zone first.</text>
+<rect x="118" y="484" width="400" height="258" fill="url(#cell)" stroke="#4b544d" stroke-width="1.6"/>
+<text x="140" y="520" fill="#eaedeb" font-size="21" font-weight="700">Spiky on peers only</text>
+<text x="140" y="546" fill="#a3aaa5" font-size="18">Flies itself well, but competes</text>
+<text x="140" y="568" fill="#a3aaa5" font-size="18">whenever cooperation is not scored.</text>
+<line x1="140" y1="588" x2="496" y2="588" stroke="#333d36" stroke-width="1"/>
+<text x="140" y="614" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
+<text x="140" y="636" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
+<text x="140" y="672" fill="#c9cfcb" font-size="17.5">The drone flies safely and efficiently,</text>
+<text x="140" y="694" fill="#c9cfcb" font-size="17.5">but will cut in front of a peer to reach</text>
+<text x="140" y="716" fill="#c9cfcb" font-size="17.5">the drop zone first.</text>
 
 <rect x="546" y="484" width="400" height="258" fill="url(#cellBest)" stroke="url(#chrome2)" stroke-width="2.6"/>
 <text x="568" y="520" fill="#ffffff" font-size="21" font-weight="700">Continuous on both axes</text>
-<text x="568" y="546" fill="#c3cedd" font-size="18">The stable quadrant. Every second is</text>
-<text x="568" y="568" fill="#c3cedd" font-size="18">priced, so there is no spike to chase.</text>
-<line x1="568" y1="588" x2="924" y2="588" stroke="#4d5867" stroke-width="1"/>
-<text x="568" y="614" fill="#aab6c6" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
-<text x="568" y="636" fill="#aab6c6" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
-<text x="568" y="672" fill="#dfe7f0" font-size="17.5">The drone stays inside its safety margins</text>
-<text x="568" y="694" fill="#dfe7f0" font-size="17.5">and holds smooth coordination with its</text>
-<text x="568" y="716" fill="#dfe7f0" font-size="17.5">peers, continuously.</text>
-<text x="118" y="770" fill="#6f7c8d" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">design reference for the multi-drone roadmap; not implemented in src/ today</text>
+<text x="568" y="546" fill="#c9cfcb" font-size="18">The stable quadrant. Every second is</text>
+<text x="568" y="568" fill="#c9cfcb" font-size="18">priced, so there is no spike to chase.</text>
+<line x1="568" y1="588" x2="924" y2="588" stroke="#525b54" stroke-width="1"/>
+<text x="568" y="614" fill="#a9afab" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
+<text x="568" y="636" fill="#a9afab" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
+<text x="568" y="672" fill="#dfe3e0" font-size="17.5">The drone stays inside its safety margins</text>
+<text x="568" y="694" fill="#dfe3e0" font-size="17.5">and holds smooth coordination with its</text>
+<text x="568" y="716" fill="#dfe3e0" font-size="17.5">peers, continuously.</text>
+<text x="118" y="770" fill="#757c77" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">design reference for the multi-drone roadmap; not implemented in src/ today</text>
 </svg>

--- a/assets/reward-shaping.svg
+++ b/assets/reward-shaping.svg
@@ -2,85 +2,85 @@
 <defs>
   <linearGradient id="bg2" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0" stop-color="#0d1410"/>
-    <stop offset="1" stop-color="#040705"/>
+    <stop offset="1" stop-color="#070b08"/>
   </linearGradient>
   <linearGradient id="chrome2" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#7a7f7c"/>
+    <stop offset="0" stop-color="#8f9491"/>
     <stop offset="0.35" stop-color="#e6e9e7"/>
-    <stop offset="0.62" stop-color="#888d8a"/>
+    <stop offset="0.62" stop-color="#9ea3a0"/>
     <stop offset="1" stop-color="#dfe3e0"/>
   </linearGradient>
   <linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#10160f"/>
-    <stop offset="1" stop-color="#0d120e"/>
+    <stop offset="0" stop-color="#182119"/>
+    <stop offset="1" stop-color="#131a14"/>
   </linearGradient>
   <linearGradient id="cellBest" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#18211a"/>
-    <stop offset="1" stop-color="#0d120e"/>
+    <stop offset="0" stop-color="#212d24"/>
+    <stop offset="1" stop-color="#141c16"/>
   </linearGradient>
 </defs>
 
 <rect x="0" y="0" width="980" height="780" fill="url(#bg2)"/>
 
 <text x="34" y="52" fill="#f2f5f3" font-size="31" font-weight="700">Reward shaping, two axes</text>
-<text x="34" y="79" fill="#8b928d" font-size="18">A spiky reward invites goal hacking. A continuous one prices the behaviour you actually want.</text>
+<text x="34" y="79" fill="#979e99" font-size="18">A spiky reward invites goal hacking. A continuous one prices the behaviour you actually want.</text>
 
-<line x1="34" y1="102" x2="946" y2="102" stroke="#232b25" stroke-width="1"/>
+<line x1="34" y1="102" x2="946" y2="102" stroke="#333d36" stroke-width="1"/>
 
-<text x="118" y="136" fill="#787f7a" font-size="16" font-weight="700" letter-spacing="1.6">PEER INTERACTION</text>
-<text x="318" y="170" fill="#9aa19c" font-size="21" font-weight="700" text-anchor="middle">event based</text>
-<text x="318" y="190" fill="#6b726d" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+Y if coop_event else 0</text>
-<text x="746" y="170" fill="#9aa19c" font-size="21" font-weight="700" text-anchor="middle">continuous</text>
-<text x="746" y="190" fill="#6b726d" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">g(coop_quality)</text>
+<text x="118" y="136" fill="#828983" font-size="16" font-weight="700" letter-spacing="1.6">PEER INTERACTION</text>
+<text x="318" y="170" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle">event based</text>
+<text x="318" y="190" fill="#757c77" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">+Y if coop_event else 0</text>
+<text x="746" y="170" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle">continuous</text>
+<text x="746" y="190" fill="#757c77" font-size="16" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">g(coop_quality)</text>
 
-<text x="0" y="0" fill="#787f7a" font-size="16" font-weight="700" letter-spacing="1.6" text-anchor="middle" transform="translate(28,470) rotate(-90)">SELF ALIGNMENT</text>
-<text x="0" y="0" fill="#9aa19c" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,333) rotate(-90)">event based</text>
-<text x="0" y="0" fill="#6b726d" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,333) rotate(-90)">+X if goal_met else 0</text>
-<text x="0" y="0" fill="#9aa19c" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,613) rotate(-90)">continuous</text>
-<text x="0" y="0" fill="#6b726d" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,613) rotate(-90)">f(alignment_score)</text>
+<text x="0" y="0" fill="#828983" font-size="16" font-weight="700" letter-spacing="1.6" text-anchor="middle" transform="translate(28,470) rotate(-90)">SELF ALIGNMENT</text>
+<text x="0" y="0" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,333) rotate(-90)">event based</text>
+<text x="0" y="0" fill="#757c77" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,333) rotate(-90)">+X if goal_met else 0</text>
+<text x="0" y="0" fill="#a9afab" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,613) rotate(-90)">continuous</text>
+<text x="0" y="0" fill="#757c77" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,613) rotate(-90)">f(alignment_score)</text>
 
-<rect x="118" y="204" width="400" height="258" fill="url(#cell)" stroke="#2e3830" stroke-width="1.6"/>
+<rect x="118" y="204" width="400" height="258" fill="url(#cell)" stroke="#4b544d" stroke-width="1.6"/>
 <text x="140" y="240" fill="#eaedeb" font-size="21" font-weight="700">Spiky on both axes</text>
-<text x="140" y="266" fill="#9aa19c" font-size="18">Unstable. Goal hacking is likely,</text>
-<text x="140" y="288" fill="#9aa19c" font-size="18">because only the spike is paid.</text>
-<line x1="140" y1="308" x2="496" y2="308" stroke="#232b25" stroke-width="1"/>
-<text x="140" y="334" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
-<text x="140" y="356" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
-<text x="140" y="392" fill="#c4cac5" font-size="17.5">The drone ignores battery and sensor</text>
-<text x="140" y="414" fill="#c4cac5" font-size="17.5">health to finish the route, and yields to</text>
-<text x="140" y="436" fill="#c4cac5" font-size="17.5">peers only when forced at a choke point.</text>
+<text x="140" y="266" fill="#a3aaa5" font-size="18">Unstable. Goal hacking is likely,</text>
+<text x="140" y="288" fill="#a3aaa5" font-size="18">because only the spike is paid.</text>
+<line x1="140" y1="308" x2="496" y2="308" stroke="#333d36" stroke-width="1"/>
+<text x="140" y="334" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
+<text x="140" y="356" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
+<text x="140" y="392" fill="#c9cfcb" font-size="17.5">The drone ignores battery and sensor</text>
+<text x="140" y="414" fill="#c9cfcb" font-size="17.5">health to finish the route, and yields to</text>
+<text x="140" y="436" fill="#c9cfcb" font-size="17.5">peers only when forced at a choke point.</text>
 
-<rect x="546" y="204" width="400" height="258" fill="url(#cell)" stroke="#2e3830" stroke-width="1.6"/>
+<rect x="546" y="204" width="400" height="258" fill="url(#cell)" stroke="#4b544d" stroke-width="1.6"/>
 <text x="568" y="240" fill="#eaedeb" font-size="21" font-weight="700">Spiky on self only</text>
-<text x="568" y="266" fill="#9aa19c" font-size="18">Cooperation looks excellent while</text>
-<text x="568" y="288" fill="#9aa19c" font-size="18">solo navigation quietly degrades.</text>
-<line x1="568" y1="308" x2="924" y2="308" stroke="#232b25" stroke-width="1"/>
-<text x="568" y="334" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
-<text x="568" y="356" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
-<text x="568" y="392" fill="#c4cac5" font-size="17.5">The drone skips its safety checks to</text>
-<text x="568" y="414" fill="#c4cac5" font-size="17.5">finish the mission, yet holds perfect</text>
-<text x="568" y="436" fill="#c4cac5" font-size="17.5">formation with its peers throughout.</text>
+<text x="568" y="266" fill="#a3aaa5" font-size="18">Cooperation looks excellent while</text>
+<text x="568" y="288" fill="#a3aaa5" font-size="18">solo navigation quietly degrades.</text>
+<line x1="568" y1="308" x2="924" y2="308" stroke="#333d36" stroke-width="1"/>
+<text x="568" y="334" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  +X if goal_met else 0</text>
+<text x="568" y="356" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
+<text x="568" y="392" fill="#c9cfcb" font-size="17.5">The drone skips its safety checks to</text>
+<text x="568" y="414" fill="#c9cfcb" font-size="17.5">finish the mission, yet holds perfect</text>
+<text x="568" y="436" fill="#c9cfcb" font-size="17.5">formation with its peers throughout.</text>
 
-<rect x="118" y="484" width="400" height="258" fill="url(#cell)" stroke="#2e3830" stroke-width="1.6"/>
+<rect x="118" y="484" width="400" height="258" fill="url(#cell)" stroke="#4b544d" stroke-width="1.6"/>
 <text x="140" y="520" fill="#eaedeb" font-size="21" font-weight="700">Spiky on peers only</text>
-<text x="140" y="546" fill="#9aa19c" font-size="18">Flies itself well, but competes</text>
-<text x="140" y="568" fill="#9aa19c" font-size="18">whenever cooperation is not scored.</text>
-<line x1="140" y1="588" x2="496" y2="588" stroke="#232b25" stroke-width="1"/>
-<text x="140" y="614" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
-<text x="140" y="636" fill="#888f8a" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
-<text x="140" y="672" fill="#c4cac5" font-size="17.5">The drone flies safely and efficiently,</text>
-<text x="140" y="694" fill="#c4cac5" font-size="17.5">but will cut in front of a peer to reach</text>
-<text x="140" y="716" fill="#c4cac5" font-size="17.5">the drop zone first.</text>
+<text x="140" y="546" fill="#a3aaa5" font-size="18">Flies itself well, but competes</text>
+<text x="140" y="568" fill="#a3aaa5" font-size="18">whenever cooperation is not scored.</text>
+<line x1="140" y1="588" x2="496" y2="588" stroke="#333d36" stroke-width="1"/>
+<text x="140" y="614" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
+<text x="140" y="636" fill="#949a95" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  +Y if coop_event else 0</text>
+<text x="140" y="672" fill="#c9cfcb" font-size="17.5">The drone flies safely and efficiently,</text>
+<text x="140" y="694" fill="#c9cfcb" font-size="17.5">but will cut in front of a peer to reach</text>
+<text x="140" y="716" fill="#c9cfcb" font-size="17.5">the drop zone first.</text>
 
 <rect x="546" y="484" width="400" height="258" fill="url(#cellBest)" stroke="url(#chrome2)" stroke-width="2.6"/>
 <text x="568" y="520" fill="#ffffff" font-size="21" font-weight="700">Continuous on both axes</text>
-<text x="568" y="546" fill="#c4cac5" font-size="18">The stable quadrant. Every second is</text>
-<text x="568" y="568" fill="#c4cac5" font-size="18">priced, so there is no spike to chase.</text>
-<line x1="568" y1="588" x2="924" y2="588" stroke="#37423a" stroke-width="1"/>
-<text x="568" y="614" fill="#9aa19c" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
-<text x="568" y="636" fill="#9aa19c" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
+<text x="568" y="546" fill="#c9cfcb" font-size="18">The stable quadrant. Every second is</text>
+<text x="568" y="568" fill="#c9cfcb" font-size="18">priced, so there is no spike to chase.</text>
+<line x1="568" y1="588" x2="924" y2="588" stroke="#525b54" stroke-width="1"/>
+<text x="568" y="614" fill="#a9afab" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">self  f(alignment_score)</text>
+<text x="568" y="636" fill="#a9afab" font-size="16" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer  g(coop_quality)</text>
 <text x="568" y="672" fill="#dfe3e0" font-size="17.5">The drone stays inside its safety margins</text>
 <text x="568" y="694" fill="#dfe3e0" font-size="17.5">and holds smooth coordination with its</text>
 <text x="568" y="716" fill="#dfe3e0" font-size="17.5">peers, continuously.</text>
-<text x="118" y="770" fill="#6b726d" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">design reference for the multi-drone roadmap; not implemented in src/ today</text>
+<text x="118" y="770" fill="#757c77" font-size="16.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">design reference for the multi-drone roadmap; not implemented in src/ today</text>
 </svg>

--- a/assets/reward-shaping.svg
+++ b/assets/reward-shaping.svg
@@ -20,7 +20,7 @@
   </linearGradient>
 </defs>
 
-<rect x="0" y="0" width="980" height="780" rx="12" fill="url(#bg2)"/>
+<rect x="0" y="0" width="980" height="780" fill="url(#bg2)"/>
 
 <text x="34" y="52" fill="#f2f6fa" font-size="31" font-weight="700">Reward shaping, two axes</text>
 <text x="34" y="79" fill="#93a1b3" font-size="18">A spiky reward invites goal hacking. A continuous one prices the behaviour you actually want.</text>
@@ -39,7 +39,7 @@
 <text x="0" y="0" fill="#aab6c6" font-size="21" font-weight="700" text-anchor="middle" transform="translate(62,613) rotate(-90)">continuous</text>
 <text x="0" y="0" fill="#6f7c8d" font-size="15.5" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" transform="translate(84,613) rotate(-90)">f(alignment_score)</text>
 
-<rect x="118" y="204" width="400" height="258" rx="9" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
+<rect x="118" y="204" width="400" height="258" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
 <text x="140" y="240" fill="#e9eff6" font-size="21" font-weight="700">Spiky on both axes</text>
 <text x="140" y="266" fill="#9dabbc" font-size="18">Unstable. Goal hacking is likely,</text>
 <text x="140" y="288" fill="#9dabbc" font-size="18">because only the spike is paid.</text>
@@ -50,7 +50,7 @@
 <text x="140" y="414" fill="#c3cedd" font-size="17.5">health to finish the route, and yields to</text>
 <text x="140" y="436" fill="#c3cedd" font-size="17.5">peers only when forced at a choke point.</text>
 
-<rect x="546" y="204" width="400" height="258" rx="9" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
+<rect x="546" y="204" width="400" height="258" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
 <text x="568" y="240" fill="#e9eff6" font-size="21" font-weight="700">Spiky on self only</text>
 <text x="568" y="266" fill="#9dabbc" font-size="18">Cooperation looks excellent while</text>
 <text x="568" y="288" fill="#9dabbc" font-size="18">solo navigation quietly degrades.</text>
@@ -61,7 +61,7 @@
 <text x="568" y="414" fill="#c3cedd" font-size="17.5">finish the mission, yet holds perfect</text>
 <text x="568" y="436" fill="#c3cedd" font-size="17.5">formation with its peers throughout.</text>
 
-<rect x="118" y="484" width="400" height="258" rx="9" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
+<rect x="118" y="484" width="400" height="258" fill="url(#cell)" stroke="#46515f" stroke-width="1.6"/>
 <text x="140" y="520" fill="#e9eff6" font-size="21" font-weight="700">Spiky on peers only</text>
 <text x="140" y="546" fill="#9dabbc" font-size="18">Flies itself well, but competes</text>
 <text x="140" y="568" fill="#9dabbc" font-size="18">whenever cooperation is not scored.</text>
@@ -72,7 +72,7 @@
 <text x="140" y="694" fill="#c3cedd" font-size="17.5">but will cut in front of a peer to reach</text>
 <text x="140" y="716" fill="#c3cedd" font-size="17.5">the drop zone first.</text>
 
-<rect x="546" y="484" width="400" height="258" rx="9" fill="url(#cellBest)" stroke="url(#chrome2)" stroke-width="2.6"/>
+<rect x="546" y="484" width="400" height="258" fill="url(#cellBest)" stroke="url(#chrome2)" stroke-width="2.6"/>
 <text x="568" y="520" fill="#ffffff" font-size="21" font-weight="700">Continuous on both axes</text>
 <text x="568" y="546" fill="#c3cedd" font-size="18">The stable quadrant. Every second is</text>
 <text x="568" y="568" fill="#c3cedd" font-size="18">priced, so there is no spike to chase.</text>


### PR DESCRIPTION
## Problem

- The README described an architecture with no implementation: Ingestion, Preprocess and Prediction agents, an alignment "Constitution", a Safety Controller and a Supervisor. `grep -rniE "constitution|ingestion|preprocess|supervisor|safety|alignment|mapf" src/` returns nothing.
- Its documented `/predict` example could not work. A dict body returns 500, a list body returns 422, because the schema declares `state: dict` while `PPOAgent.predict` calls `torch.tensor(state)`.
- `python src/main.py --config configs/train.yaml` does not run; `main.py` has no argument parsing. Install instructions omitted the required `pip install -e .`.
- Design images were linked at the repository root but live in `architecture/`, and the hand-drawn panoramas were unreadable at README scale.
- `num_drones` and `obstacle_density` are read from config and never used, and there is no MAPF planner, so the repository name promised more than `src/` delivers.

## Fix

- Rewrote around the integrity-validator layer, the part that is real and distinctive: the split between **drift** (a value leaving its declared range) and **hallucination** (a value that was never legal).
- **Five diagrams**, hand-authored SVG rather than mermaid, because GitHub renders mermaid in a fixed cross-origin iframe that markdown cannot resize: `hero`, `drift-vs-hallucination`, `architecture`, `reward-shaping`, `low-level-design`. Each polished diagram carries an expandable ASCII fallback.
- **Scope and status table** separating implemented from designed, plus a **Known gaps** section documenting the `/predict` contract with both failure responses rather than printing an example that fails.
- Hand-drawn panoramas removed from the README and reconstructed; they remain in `architecture/` for provenance.
- Corrected every command, image path and directory name. Added a configuration audit: only `configs/env.yaml` is read; `train.yaml` and `env-prod.yaml` are read by nothing.
- Removed `.github/dependabot.yml` (carried in from `main`).

## Tests

Documentation and asset change; no source files touched. Claims verified by execution and by measurement in the browser, not by reading.

- [x] Happy path: `python -m main` runs clean in the CI image, exit 0, writes `models/ppo_drone.pt`, reports `Drift errors: 0` and `Hallucination errors: 0` over 2000 steps
- [x] Happy path: `GET /healthz` returns `{"status":"ok"}` and `GET /metrics` returns Prometheus format against the running image
- [x] Edge cases: both documented `/predict` failures reproduced live, 422 for a list body and 500 for a dict body
- [x] Automated UI sanity: all five SVGs confirmed loading on the rendered GitHub page, `0` mermaid blocks and `0` legacy scans remaining
- [x] Automated UI sanity: legibility measured at 75% browser zoom. The column shrinks to 627px, so the diagrams were rebuilt to two wide columns; body text now renders at 12.2px, up from 9.9px
- [x] Unit: every local path referenced by the README confirmed to exist; README and all SVGs scanned clean for em dashes, en dashes, arrow glyphs and smart quotes
- [x] Unit: `0` rounded corners and `0` blue-dominant colours remain across the four themed diagrams

🤖 Generated with [Claude Code](https://claude.com/claude-code)
