### PR TITLE
Fix the /predict contract and make configs/train.yaml actually apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 <img alt="python 3.10" src="https://img.shields.io/badge/python-3.10-dfe3e0?style=flat-square&labelColor=0d1410">
 <img alt="PPO in PyTorch 2.2.2" src="https://img.shields.io/badge/PPO-PyTorch_2.2.2-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="env gymnasium" src="https://img.shields.io/badge/env-gymnasium-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="tests 6 passing" src="https://img.shields.io/badge/tests-6_passing-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="coverage 85 percent" src="https://img.shields.io/badge/coverage-85%25-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="tests 6 passing" src="https://img.shields.io/badge/tests-15_passing-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="coverage 85 percent" src="https://img.shields.io/badge/coverage-84%25-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="license Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-8f9491?style=flat-square&labelColor=0d1410">
 
 <br/><br/>
@@ -234,7 +234,7 @@ Only one config file is actually read by the code today.
 | file | read by | status |
 |---|---|---|
 | [`configs/env.yaml`](configs/env.yaml) | `DroneEnv._load_config` | **Live** |
-| [`configs/train.yaml`](configs/train.yaml) | nothing | **Dead**. Referenced only by the broken `scripts/train.sh` |
+| [`configs/train.yaml`](configs/train.yaml) | `main.load_train_config` | **Live**, via `--config` |
 | [`configs/env-prod.yaml`](configs/env-prod.yaml) | nothing | **Dead** |
 | `.env` (see [`.env.example`](.env.example)) | `scripts/run_server.sh` only | Shell-level. No Python module reads an environment variable |
 
@@ -274,8 +274,8 @@ Worth reading before the deployment sections. The repository name is older than 
 | `IntegrityStats` reporting across a run | **Implemented** |
 | FastAPI service, `/metrics` and `/healthz` | **Implemented** |
 | Docker image, Compose, Kubernetes manifests, Prometheus and Grafana config | **Implemented** as configuration |
-| `/predict` end to end | **Broken**, see Known gaps |
-| Hyperparameters from `configs/train.yaml` | **Not wired**, defaults live in Python |
+| `/predict` end to end | **Implemented**. Takes the 5-number observation vector |
+| Hyperparameters from `configs/train.yaml` | **Implemented**. Loaded and applied to `PPOAgent` |
 | Multi-agent, more than one drone | **Not implemented**. `num_drones` is read into an attribute and never used; the env tracks a single position vector |
 | MAPF, multi-agent path finding | **Not implemented**. No conflict resolution, no reservation table, no joint planner |
 | Obstacles | **Not implemented**. `obstacle_density` is read and never used |
@@ -327,29 +327,18 @@ Full written spec in [`architecture/low_level_design.txt`](architecture/low_leve
 
 ### Known gaps
 
-**`/predict` currently rejects every input.** The request schema declares `state: dict`, while `PPOAgent.predict` calls `torch.tensor(state)` and needs a numeric sequence. No body satisfies both:
-
-```
-{"state": [0,0,19,19,200]}   ->  422  pydantic: "Input should be a valid dictionary"
-{"state": {"x": 1, "y": 2}}  ->  500  "Prediction failed: must be real number, not dict"
-```
-
-`tests/test_api.py` does not catch this, because it replaces `PPOAgent` with a stub that returns a constant. The fix is to agree on one contract, most naturally the 5-number observation vector, then make the schema and the agent match. Note that `predict` returns an integer index, while `src/request_response_flow.MD` documents a response of `{"action": "move_up"}`; the same fix should decide whether the API speaks indices or names.
-
-**`scripts/train.sh` does not run.** It invokes `python src/main.py --config configs/train.yaml`, but `main.py` has no argument parsing and the `src/` layout needs the editable install. Use `python -m main`.
-
 **`tests/conftest.py` swallows import errors.** It catches any failure importing the real `DroneEnv` and substitutes a stub. That is why a missing dependency once surfaced as `AttributeError: 'DroneEnv' object has no attribute 'reset'` rather than an import error, and why coverage sat at 38 percent while appearing to exercise the environment.
 
 ### Roadmap
 
 Roughly in dependency order:
 
-1. Fix the `/predict` contract, and cover it with a test that does not stub the agent.
-2. Wire `configs/train.yaml` into `PPOAgent` so hyperparameters stop being Python defaults.
-3. Obstacles, using the `obstacle_density` field that already exists in config.
-4. Multiple drones: a per-drone observation and action, and a reward that prices collisions.
-5. MAPF proper: conflict detection between planned paths, then a resolution strategy.
-6. Safety Controller, the first component allowed to veto rather than only report.
+1. Obstacles, using the `obstacle_density` field that already exists in config.
+2. Multiple drones: a per-drone observation and action, and a reward that prices collisions.
+3. MAPF proper: conflict detection between planned paths, then a resolution strategy.
+4. Safety Controller, the first component allowed to veto rather than only report.
+
+Done: the `/predict` contract now takes the 5-number observation vector and is covered by tests that do not stub the agent, and `configs/train.yaml` is loaded and applied rather than silently discarded.
 
 ---
 
@@ -402,7 +391,12 @@ curl http://localhost:8000/healthz
 # {"status":"ok"}
 ```
 
-`/predict` is reachable but not yet usable. See Known gaps.
+```bash
+curl -X POST http://localhost:8000/predict \
+  -H "Content-Type: application/json" \
+  -d '{"state": [0, 0, 19, 19, 200]}'
+# {"action":1,"action_name":"up"}
+```
 
 ---
 
@@ -410,7 +404,7 @@ curl http://localhost:8000/healthz
 
 | method | path | purpose | status |
 |---|---|---|---|
-| `POST` | `/predict` | Greedy action from the loaded policy | Reachable, contract broken |
+| `POST` | `/predict` | Greedy action from the loaded policy | Working |
 | `GET` | `/metrics` | Prometheus exposition format | Working |
 | `GET` | `/healthz` | Liveness and readiness probe | Working |
 
@@ -430,10 +424,11 @@ pytest --cov=src --cov-report=term-missing
 | `tests/test_integrity.py` | A legal step produces no integrity errors; the policy validator flags negative probabilities, non-finite values and out-of-space actions |
 | `tests/test_training.py` | Train, save and reload, then a short greedy rollout |
 | `tests/test_integration.py` | Environment and agent wired together |
-| `tests/test_api.py` | `/predict` against a stubbed agent |
+| `tests/test_api.py` | `/predict` against the real agent: a legal action, and 422 for a wrong-length or mapping body |
+| `tests/test_main_config.py` | `--config` is parsed, applied to `PPOAgent`, and unknown flags exit non-zero |
 | `tests/test_load.py` | Repeated stepping under pressure |
 
-Current state on `main`: 6 passing, 85 percent line coverage.
+Current state: 15 passing, 84 percent line coverage.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 <img alt="python 3.10" src="https://img.shields.io/badge/python-3.10-dfe3e0?style=flat-square&labelColor=0d1410">
 <img alt="PPO in PyTorch 2.2.2" src="https://img.shields.io/badge/PPO-PyTorch_2.2.2-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="env gymnasium" src="https://img.shields.io/badge/env-gymnasium-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="tests 6 passing" src="https://img.shields.io/badge/tests-15_passing-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="coverage 85 percent" src="https://img.shields.io/badge/coverage-84%25-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="tests 15 passing" src="https://img.shields.io/badge/tests-15_passing-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="coverage 84 percent" src="https://img.shields.io/badge/coverage-84%25-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="license Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-8f9491?style=flat-square&labelColor=0d1410">
 
 <br/><br/>

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
-# Runs training with the specified config
+# Runs training with the specified config.
+# Extra arguments are passed through, so a short run is:
+#   scripts/train.sh --episodes 10
 set -e
-python src/main.py --config configs/train.yaml
+python src/main.py --config configs/train.yaml "$@"

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -7,9 +7,10 @@
 #  - Error handling (so the API fails gracefully)
 #  - Health check endpoint (so Kubernetes can verify the service is alive)
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import PlainTextResponse, JSONResponse
 from pydantic import BaseModel
+from typing import List
 import time
 
 # Prometheus metrics utilities
@@ -28,8 +29,15 @@ from src.agents.ppo_agent import PPOAgent
 
 
 class StateInput(BaseModel):
-    """Schema for the prediction request body."""
-    state: dict
+    """Schema for the prediction request body.
+
+    ``state`` is one environment observation, flat and in the order the
+    environment emits it: ``[x, y, goal_x, goal_y, steps_remaining]``. It is a
+    list of numbers rather than a mapping because that is what the policy
+    consumes; ``PPOAgent.predict`` builds a tensor straight from it.
+    """
+
+    state: List[float]
 
 
 # -------------------------------------------------
@@ -86,16 +94,30 @@ async def add_metrics(request: Request, call_next):
 def predict(payload: StateInput):
     """
     Accepts a payload matching :class:`StateInput` and returns the agent's action.
-    Example request: { "state": {...} }
-    Example response: { "action": ... }
+
+    Example request:  { "state": [0, 0, 19, 19, 200] }
+    Example response: { "action": 4, "action_name": "right" }
+
+    The action is returned both ways on purpose. The index is what the
+    environment's ``step()`` accepts; the name is what a human reads in a log.
     """
     logger.info("Received predict request")
+
+    expected = int(env.observation_space.shape[0])
+    if len(payload.state) != expected:
+        # A wrong-length observation is a client error, not a server fault, so
+        # it is rejected before it can reach the policy as an opaque failure.
+        raise HTTPException(
+            status_code=422,
+            detail=f"state must have exactly {expected} values, got {len(payload.state)}",
+        )
+
     try:
         action = agent.predict(payload.state)
     except Exception as e:
         # Wrap raw exceptions in a clean APIError
         raise APIError(f"Prediction failed: {str(e)}", status_code=500)
-    return {"action": action}
+    return {"action": action, "action_name": env.action_map[action]}
 
 
 @app.get("/metrics")

--- a/src/main.py
+++ b/src/main.py
@@ -14,30 +14,79 @@ Why separate this?
 -> This separation mirrors good software engineering practice.
 """
 
+import argparse
 import os
+from pathlib import Path
+from typing import Any, Dict
+
 from env.drone_env import DroneEnv
 from agents.ppo_agent import PPOAgent
 from integrity_stats import IntegrityStats  # tracks drift vs hallucination stats
 
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover
+    yaml = None
 
-def train_and_save(model_path="models/ppo_drone.pt", num_episodes=10):
+
+def load_train_config(config_path=None) -> Dict[str, Any]:
+    """
+    Read training hyperparameters from a YAML file.
+
+    Returns an empty dict when no path is given or the file is absent, so the
+    caller keeps its own defaults rather than crashing. Passing a path that
+    does not exist is a caller mistake and is reported as one.
+    """
+    if config_path is None:
+        return {}
+
+    path = Path(config_path)
+    if not path.is_absolute():
+        # Resolve relative to the project root, one level above src, so the
+        # same invocation works from the repo root and from inside src.
+        path = Path(__file__).resolve().parents[1] / path
+    if not path.exists():
+        raise FileNotFoundError(f"training config not found: {config_path}")
+
+    with path.open("r") as f:
+        if yaml is not None:
+            return yaml.safe_load(f) or {}
+        # Fallback parser for key: value lines, matching DroneEnv's behaviour.
+        data: Dict[str, Any] = {}
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            value = value.strip()
+            data[key.strip()] = float(value) if "." in value else int(value)
+        return data
+
+
+def train_and_save(model_path="models/ppo_drone.pt", num_episodes=10, config=None):
     """
     End-to-end training routine.
 
     Steps:
     1. Create environment.
-    2. Create PPO agent.
+    2. Create PPO agent, using any hyperparameters supplied in ``config``.
     3. Train agent for a given number of episodes.
     4. Save the trained model to disk.
     5. Print an integrity report.
     """
     stats = IntegrityStats()
+    config = config or {}
 
     # Step 1 -> Environment
     env = DroneEnv()
 
-    # Step 2 -> Agent
-    agent = PPOAgent(env)
+    # Step 2 -> Agent. Anything absent from the config keeps the PPOAgent default.
+    agent_kwargs = {}
+    if "learning_rate" in config:
+        agent_kwargs["lr"] = float(config["learning_rate"])
+    if "gamma" in config:
+        agent_kwargs["gamma"] = float(config["gamma"])
+    agent = PPOAgent(env, **agent_kwargs)
 
     # Monkey-patch validator to record stats after each check
     original_validate = agent.validator.validate
@@ -92,9 +141,51 @@ def run_inference(agent, env, rollout_len=5):
     stats.report(prefix="[Inference Integrity Report]")
 
 
-if __name__ == "__main__":
-    # Run training and save model
-    agent, env = train_and_save(num_episodes=10)
+def parse_args(argv=None):
+    """Command line surface for a training run."""
+    parser = argparse.ArgumentParser(
+        prog="main",
+        description="Train the PPO drone agent, save it, then run a short inference rollout.",
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="YAML file of training hyperparameters, for example configs/train.yaml",
+    )
+    parser.add_argument(
+        "--episodes",
+        type=int,
+        default=None,
+        help="Number of training episodes. Overrides num_episodes from the config file.",
+    )
+    parser.add_argument(
+        "--model-path",
+        default="models/ppo_drone.pt",
+        help="Where to write the trained weights.",
+    )
+    parser.add_argument(
+        "--rollout-len",
+        type=int,
+        default=5,
+        help="Number of inference steps to run after training.",
+    )
+    return parser.parse_args(argv)
 
-    # Run quick inference test
-    run_inference(agent, env)
+
+def main(argv=None):
+    args = parse_args(argv)
+    config = load_train_config(args.config)
+
+    # Precedence: explicit flag, then config file, then the built-in default.
+    episodes = args.episodes
+    if episodes is None:
+        episodes = int(config.get("num_episodes", 10))
+
+    agent, env = train_and_save(
+        model_path=args.model_path, num_episodes=episodes, config=config
+    )
+    run_inference(agent, env, rollout_len=args.rollout_len)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,91 +1,45 @@
-import sys
-import types
+"""
+API tests, run against the real agent.
+
+These deliberately do not stub PPOAgent. An earlier version of this file
+replaced the agent with a dummy that returned a constant, which meant the
+/predict contract could be broken without a single test noticing, and it was.
+"""
+
 import pytest
 from fastapi.testclient import TestClient
 
-# ===============================================================
-# WHY DO WE NEED STUBS?
-# ---------------------------------------------------------------
-# In production, our FastAPI app imports:
-#   - src.env.drone_env.DroneEnv (a Gym environment, heavy dep)
-#   - src.agents.ppo_agent.PPOAgent (a PyTorch model, heavy dep)
-#
-# Problem: when we run API tests in CI, those libraries (gym,
-# PyTorch) may not be installed. Importing them directly would
-# crash the test collection with ModuleNotFoundError.
-#
-# Solution: we "stub" those modules with lightweight fake
-# replacements. They have the same *interface* (same methods,
-# same names) but skip all heavy logic. This way:
-#   - The FastAPI app can import successfully.
-#   - The /predict endpoint still works for tests.
-#   - No GPU, model weights, or external deps are required.
-# ===============================================================
+from src.api.app import app, env
 
-# --- ENVIRONMENT STUB ---
-# Fake DroneEnv just defines observation/action spaces.
-class DummyEnv:
-    def __init__(self, *_):
-        self.observation_space = types.SimpleNamespace(shape=(2,))
-        self.action_space = types.SimpleNamespace(n=2)
-
-    def close(self):
-        pass  # real env would clean up resources
-
-# Register a fake "src.env" and "src.env.drone_env"
-# so that when FastAPI imports them, it gets our dummy version.
-env_pkg = types.ModuleType("src.env")
-env_pkg.__path__ = []  # mark as package
-env_mod = types.ModuleType("src.env.drone_env")
-env_mod.DroneEnv = DummyEnv
-sys.modules["src.env"] = env_pkg
-sys.modules["src.env.drone_env"] = env_mod
-
-# --- AGENT STUB ---
-# Fake PPOAgent that pretends to load and predict.
-ppo_agent_mod = types.ModuleType("src.agents.ppo_agent")
-
-class DummyAgent:
-    def __init__(self, env):
-        pass  # ignore env
-    def load(self, path):
-        pass  # skip model loading
-    def predict(self, state):
-        return "stub_action"  # always same action for tests
-
-ppo_agent_mod.PPOAgent = DummyAgent
-sys.modules["src.agents.ppo_agent"] = ppo_agent_mod
-
-# ===============================================================
-# WHY IMPORT APP INSIDE FIXTURE?
-# ---------------------------------------------------------------
-# If we import src.api.app at the top of this file,
-# it will try to pull in env + PPOAgent immediately.
-# That would fail before our stubs are installed.
-#
-# Instead, we import the app only *after* stubbing,
-# inside the pytest fixture. This ensures the app
-# sees DummyEnv + DummyAgent, not the real heavy ones.
-# ===============================================================
 
 @pytest.fixture
 def client():
-    from src.api.app import app  # safe now, stubs are ready
-    with TestClient(app) as c:   # context manager ensures
-        yield c                  # startup/shutdown events fire
+    with TestClient(app) as c:
+        yield c
 
-# ===============================================================
-# TESTS
-# ---------------------------------------------------------------
-# What are we actually testing?
-# - That the FastAPI /predict endpoint runs end-to-end
-# - That it calls our DummyAgent.predict()
-# - That it returns the expected JSON {"action": "stub_action"}
-# ===============================================================
 
-def test_predict(client):
-    payload = {"state": {"x": 1, "y": 2}}
-    response = client.post("/predict", json=payload)
+def test_predict_returns_a_legal_action(client):
+    """A real observation produces an action inside the action space."""
+    obs, _ = env.reset()
+    response = client.post("/predict", json={"state": obs.tolist()})
 
     assert response.status_code == 200
-    assert response.json() == {"action": "stub_action"}
+    body = response.json()
+    assert body["action"] in range(env.action_space.n)
+    assert body["action_name"] == env.action_map[body["action"]]
+
+
+def test_predict_rejects_a_wrong_length_state(client):
+    """Too few values is a client error, not a policy failure."""
+    response = client.post("/predict", json={"state": [0, 0, 1]})
+    assert response.status_code == 422
+
+
+def test_predict_rejects_a_mapping_state(client):
+    """The old contract accepted a dict here; it never worked, so it is refused."""
+    response = client.post("/predict", json={"state": {"x": 1, "y": 2}})
+    assert response.status_code == 422
+
+
+def test_healthz(client):
+    assert client.get("/healthz").json() == {"status": "ok"}

--- a/tests/test_main_config.py
+++ b/tests/test_main_config.py
@@ -1,0 +1,58 @@
+"""
+Training configuration tests.
+
+configs/train.yaml used to be read by nothing: main.py had no argument parsing,
+so `--config` was silently discarded by Python and the file never took effect.
+These lock in that the flag is parsed and that unknown flags fail loudly.
+"""
+
+import pytest
+
+from main import load_train_config, parse_args
+
+
+def test_load_train_config_reads_the_shipped_file():
+    config = load_train_config("configs/train.yaml")
+    assert config["num_episodes"] == 10000
+    assert config["learning_rate"] == pytest.approx(0.0003)
+    assert config["gamma"] == pytest.approx(0.99)
+
+
+def test_load_train_config_without_a_path_returns_empty():
+    assert load_train_config(None) == {}
+
+
+def test_load_train_config_raises_on_a_missing_file():
+    with pytest.raises(FileNotFoundError):
+        load_train_config("configs/does-not-exist.yaml")
+
+
+def test_config_flag_is_parsed_rather_than_discarded():
+    args = parse_args(["--config", "configs/train.yaml", "--episodes", "2"])
+    assert args.config == "configs/train.yaml"
+    assert args.episodes == 2
+
+
+def test_unknown_flags_fail_loudly():
+    """The original defect: an unrecognised flag was silently ignored."""
+    with pytest.raises(SystemExit):
+        parse_args(["--not-a-real-flag"])
+
+
+def test_config_values_actually_reach_the_agent(tmp_path):
+    """
+    Loading the file is not enough; the values must be applied.
+
+    Deliberately uses numbers that differ from the PPOAgent defaults. The
+    shipped train.yaml sets learning_rate to 0.0003, which is exactly the
+    default, so a run using it cannot distinguish applied from ignored.
+    """
+    from main import train_and_save
+
+    agent, _ = train_and_save(
+        model_path=str(tmp_path / "m.pt"),
+        num_episodes=1,
+        config={"learning_rate": 0.00711, "gamma": 0.5},
+    )
+    assert agent.optimizer.param_groups[0]["lr"] == pytest.approx(0.00711)
+    assert agent.gamma == pytest.approx(0.5)


### PR DESCRIPTION
## Problem

- **`/predict` accepted no valid input.** The schema declared `state: dict` while `PPOAgent.predict` calls `torch.tensor(state)`. A list body was rejected by pydantic with 422; a dict body reached the policy and failed with 500. No body satisfied both.
- `tests/test_api.py` never caught it, because it replaced `PPOAgent` with a stub returning a constant. Same stub-masking pattern that hid the gymnasium import break.
- **`configs/train.yaml` was read by nothing.** `main.py` had no argument parsing, so Python silently discarded `--config configs/train.yaml` from `scripts/train.sh`. Worth being precise: that script did **not** fail. It ran and quietly ignored the flag, which is the worse failure mode.
- `predict` returns an integer index while `src/request_response_flow.MD` documents `{"action": "move_up"}`; the two disagreed.

## Fix

- **`/predict` contract is now the 5-number observation vector**, matching `DroneEnv.observation_space`. A wrong-length vector is rejected as 422 before it reaches the policy, rather than surfacing as an opaque 500.
- The response carries **both** the action index and its name, settling the indices-against-names disagreement: `{"action": 1, "action_name": "up"}`.
- **`main.py` parses arguments**: `--config`, `--episodes`, `--model-path`, `--rollout-len`. Config supplies `learning_rate` and `gamma` to `PPOAgent`; precedence is flag, then config, then built-in default. Unknown flags now exit non-zero.
- `scripts/train.sh` passes extra arguments through, so a short run is `scripts/train.sh --episodes 10`.
- README corrected, including my own earlier inaccurate claim that `train.sh` did not run.

## Tests

Verified by running, not by reading.

- [x] Happy path: `POST /predict` with `{"state": [0,0,19,19,200]}` returns **200** `{"action":1,"action_name":"up"}` against the live container
- [x] Edge cases: wrong-length body returns **422** `state must have exactly 5 values, got 3`; a mapping body returns **422** from pydantic, where it previously returned 500
- [x] Integration: `tests/test_api.py` rewritten to exercise the real `PPOAgent` and `DroneEnv`, no stubs
- [x] Unit: `--config` is parsed rather than discarded, and an unknown flag exits **2** with `unrecognized arguments`
- [x] Unit: config values are observed on the agent, `lr 0.0003 -> 0.00711` and `gamma 0.99 -> 0.5`, using values that differ from the defaults. The shipped `train.yaml` cannot demonstrate this, since its `learning_rate` equals the `PPOAgent` default
- [x] Happy path: `python src/main.py --config configs/train.yaml --episodes 2 --rollout-len 2` exits 0 with a clean integrity report
- [x] Suite: **6 to 15 tests**, 84 percent line coverage, green in the Docker image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
