### PR TITLE
Implement obstacles, with local sensing so avoidance is learnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 <img alt="python 3.10" src="https://img.shields.io/badge/python-3.10-dfe3e0?style=flat-square&labelColor=0d1410">
 <img alt="PPO in PyTorch 2.2.2" src="https://img.shields.io/badge/PPO-PyTorch_2.2.2-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="env gymnasium" src="https://img.shields.io/badge/env-gymnasium-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="tests 15 passing" src="https://img.shields.io/badge/tests-15_passing-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="coverage 84 percent" src="https://img.shields.io/badge/coverage-84%25-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="tests 23 passing" src="https://img.shields.io/badge/tests-23_passing-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="coverage 85 percent" src="https://img.shields.io/badge/coverage-85%25-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="license Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-8f9491?style=flat-square&labelColor=0d1410">
 
 <br/><br/>
@@ -107,7 +107,8 @@ The control loop is small. The validators hang off both halves of it, and everyt
                     |
   ENVIRONMENT  DroneEnv (gymnasium)
                     |  reset() / step(action)  ->  obs, reward, terminated, truncated, info
-                    |  observation   Box(5)        x, y, goal_x, goal_y, steps_remaining
+                    |  observation   Box(9)        x, y, goal_x, goal_y, steps_remaining,
+                    |                              blocked up/down/left/right
                     |  action        Discrete(5)   hover, up, down, left, right (clamped)
                     v
   AGENT        PPOAgent (PyTorch)
@@ -136,13 +137,16 @@ The original hand-drawn design panoramas are kept in [`architecture/`](architect
 
 A grid world, deliberately small, so the validator layer is the thing under test rather than the control problem.
 
-**Observation**, a `Box` of shape `(5,)`, `float32`:
+**Observation**, a `Box` of shape `(9,)`, `float32`:
 
 | index | field | range |
 |---|---|---|
 | 0, 1 | drone `x`, `y` | `0` to `grid_size - 1` |
 | 2, 3 | goal `x`, `y` | `0` to `grid_size - 1` |
 | 4 | `steps_remaining` | `0` to `max_steps` |
+| 5 to 8 | blocked up, down, left, right | `0` or `1` |
+
+The last four are local sensing, in action order. They exist because blocking movement alone is useless: a drone that cannot see an obstacle before hitting it cannot learn to route around one, so obstacles would be nothing but a tax on a blind policy. A grid edge reads as blocked too.
 
 Bounds are per-dimension, for the reason described above. One scalar bound cannot describe both a coordinate and a step counter.
 
@@ -158,7 +162,7 @@ Bounds are per-dimension, for the reason described above. One scalar bound canno
 
 Moves clamp at the grid edge, so an illegal move is absorbed rather than rejected. `action_map` carries the human-readable names.
 
-**Reward**: `+10.0` on reaching the goal, `-1.0` per step otherwise. `terminated` on goal, `truncated` at `max_steps`. The agent starts at the origin and the goal sits at the far corner, so the shortest path under this config is 38 moves.
+**Reward**: `+10.0` on reaching the goal, `-2.0` for a step that runs into an obstacle, `-1.0` otherwise. `terminated` on goal, `truncated` at `max_steps`. The agent starts at the origin and the goal sits at the far corner, so the shortest unobstructed path under this config is 38 moves. A collision costs more than a wasted step; if it cost the same, nothing would tell the policy to route around anything.
 
 That shipped reward is deliberately spiky: the goal bonus is an event, not a gradient. It is the top left quadrant below, and it is the cheapest thing that works for a single drone. Once more than one drone shares the grid, the quadrant matters, because a spike is exactly what a policy learns to farm.
 
@@ -242,7 +246,7 @@ Only one config file is actually read by the code today.
 # configs/env.yaml, the one that is loaded
 grid_size: 20
 num_drones: 10          # read into an attribute, never used
-obstacle_density: 0.1   # read into an attribute, never used
+obstacle_density: 0.1   # obstacle rate per cell, start and goal always clear
 max_steps: 200
 ```
 
@@ -278,7 +282,7 @@ Worth reading before the deployment sections. The repository name is older than 
 | Hyperparameters from `configs/train.yaml` | **Implemented**. Loaded and applied to `PPOAgent` |
 | Multi-agent, more than one drone | **Not implemented**. `num_drones` is read into an attribute and never used; the env tracks a single position vector |
 | MAPF, multi-agent path finding | **Not implemented**. No conflict resolution, no reservation table, no joint planner |
-| Obstacles | **Not implemented**. `obstacle_density` is read and never used |
+| Obstacles | **Implemented**. Drawn from `obstacle_density`, refuse movement, and are locally sensed |
 | Ingestion, Preprocess and Prediction agents; Safety Controller; Supervisor | **Design only**, described in [`architecture/summary.md`](architecture/summary.md), no code in `src/` |
 
 The multi-agent and MAPF pieces are the roadmap the name points at, not a description of `src/`.
@@ -333,12 +337,11 @@ Full written spec in [`architecture/low_level_design.txt`](architecture/low_leve
 
 Roughly in dependency order:
 
-1. Obstacles, using the `obstacle_density` field that already exists in config.
-2. Multiple drones: a per-drone observation and action, and a reward that prices collisions.
-3. MAPF proper: conflict detection between planned paths, then a resolution strategy.
-4. Safety Controller, the first component allowed to veto rather than only report.
+1. Multiple drones: a per-drone observation and action, and a reward that prices collisions.
+2. MAPF proper: conflict detection between planned paths, then a resolution strategy.
+3. Safety Controller, the first component allowed to veto rather than only report.
 
-Done: the `/predict` contract now takes the 5-number observation vector and is covered by tests that do not stub the agent, and `configs/train.yaml` is loaded and applied rather than silently discarded.
+Done: obstacles are generated and sensed, the `/predict` contract now takes the 5-number observation vector and is covered by tests that do not stub the agent, and `configs/train.yaml` is loaded and applied rather than silently discarded.
 
 ---
 
@@ -394,8 +397,8 @@ curl http://localhost:8000/healthz
 ```bash
 curl -X POST http://localhost:8000/predict \
   -H "Content-Type: application/json" \
-  -d '{"state": [0, 0, 19, 19, 200]}'
-# {"action":1,"action_name":"up"}
+  -d '{"state": [0, 0, 19, 19, 200, 1, 1, 1, 0]}'
+# {"action":4,"action_name":"right"}
 ```
 
 ---
@@ -426,9 +429,10 @@ pytest --cov=src --cov-report=term-missing
 | `tests/test_integration.py` | Environment and agent wired together |
 | `tests/test_api.py` | `/predict` against the real agent: a legal action, and 422 for a wrong-length or mapping body |
 | `tests/test_main_config.py` | `--config` is parsed, applied to `PPOAgent`, and unknown flags exit non-zero |
+| `tests/test_obstacles.py` | Density, determinism, refused moves, the collision penalty, and the sensor flags |
 | `tests/test_load.py` | Repeated stepping under pressure |
 
-Current state: 15 passing, 84 percent line coverage.
+Current state: 23 passing, 85 percent line coverage.
 
 ---
 

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -52,7 +52,7 @@
 <text x="34" y="88" fill="#f2f5f3" font-size="34" font-weight="700" letter-spacing="0.4">Architecture</text>
 <text x="34" y="118" fill="#939a95" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
 <rect x="700" y="30" width="2" height="62" fill="#333d36"/>
-<text x="946" y="52" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5 obs dims / 5 actions</text>
+<text x="946" y="52" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">9 obs dims / 5 actions</text>
 <text x="946" y="78" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
 
 <text x="62" y="170" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
@@ -80,8 +80,8 @@
 <rect x="526" y="372" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="538" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="548" y="408" fill="#ecefed" font-size="22" font-weight="700">spaces</text>
-<text x="548" y="442" fill="#a5aca7" font-size="19">observation Box(5): x, y, goal x,</text>
-<text x="548" y="470" fill="#a5aca7" font-size="19">goal y, steps remaining</text>
+<text x="548" y="442" fill="#a5aca7" font-size="19">observation Box(9): x, y, goal x, goal y,</text>
+<text x="548" y="470" fill="#a5aca7" font-size="19">steps remaining, plus 4 sensor flags</text>
 <text x="548" y="504" fill="#a5aca7" font-size="19">action Discrete(5), edge clamped</text>
 
 <path d="M 482 448 L 518 448" stroke="#949a96" stroke-width="2" fill="none" marker-end="url(#a)"/>

--- a/src/env/drone_env.py
+++ b/src/env/drone_env.py
@@ -36,12 +36,16 @@ class DroneEnv(gym.Env):
         self.obstacle_density: float = float(self.config.get("obstacle_density", 0.0))
         self.max_steps: int = int(self.config.get("max_steps", 100))
 
-        # Observation: [x, y, goal_x, goal_y, steps_remaining]
-        # Bounds are per-dimension: the four coordinates are clamped to the grid,
-        # while steps_remaining counts down from max_steps. A single scalar bound
-        # would put every steps_remaining > grid_size outside the declared space.
+        # Observation: [x, y, goal_x, goal_y, steps_remaining,
+        #               blocked_up, blocked_down, blocked_left, blocked_right]
+        # Bounds are per-dimension: the coordinates are clamped to the grid, while
+        # steps_remaining counts down from max_steps. A single scalar bound would
+        # put every steps_remaining > grid_size outside the declared space.
+        # The four trailing flags are local sensing. Without them a drone cannot
+        # see an obstacle before hitting it, so avoidance is not learnable and the
+        # obstacles would only ever be a tax on a blind policy.
         self.observation_space = spaces.Box(
-            low=np.zeros(5, dtype=np.float32),
+            low=np.zeros(9, dtype=np.float32),
             high=np.array(
                 [
                     self.grid_size - 1,
@@ -49,6 +53,10 @@ class DroneEnv(gym.Env):
                     self.grid_size - 1,
                     self.grid_size - 1,
                     self.max_steps,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
                 ],
                 dtype=np.float32,
             ),
@@ -70,6 +78,8 @@ class DroneEnv(gym.Env):
         self.position = np.zeros(2, dtype=np.float32)
         self.goal = np.array([self.grid_size - 1, self.grid_size - 1], dtype=np.float32)
         self.steps = 0
+        # Populated on reset, once the seeded RNG exists.
+        self.obstacles = np.zeros((self.grid_size, self.grid_size), dtype=bool)
 
     # ------------------------------------------------------------------
     # Utility methods
@@ -93,10 +103,51 @@ class DroneEnv(gym.Env):
                     data[key.strip()] = float(value) if "." in value else int(value)
             return data
 
+    def _generate_obstacles(self) -> np.ndarray:
+        """Draw a fresh obstacle grid from the seeded RNG.
+
+        The start and goal cells are always cleared. A blocked start would make
+        the episode meaningless, and a blocked goal would make it unwinnable, so
+        neither is left to chance.
+        """
+        grid = np.zeros((self.grid_size, self.grid_size), dtype=bool)
+        if self.obstacle_density <= 0:
+            return grid
+
+        grid = self.np_random.random((self.grid_size, self.grid_size)) < self.obstacle_density
+        grid[0, 0] = False
+        grid[self.grid_size - 1, self.grid_size - 1] = False
+        return grid
+
+    def _is_obstacle(self, x: int, y: int) -> bool:
+        """True when the cell holds an obstacle. Out of bounds is not an obstacle."""
+        if not (0 <= x < self.grid_size and 0 <= y < self.grid_size):
+            return False
+        return bool(self.obstacles[x, y])
+
+    def _is_impassable(self, x: int, y: int) -> bool:
+        """What the drone's local sensor reports: a wall reads the same as an obstacle."""
+        if not (0 <= x < self.grid_size and 0 <= y < self.grid_size):
+            return True
+        return bool(self.obstacles[x, y])
+
+    def _sensor_flags(self) -> list:
+        """Blocked flags for the four moves, in action order: up, down, left, right."""
+        x, y = int(self.position[0]), int(self.position[1])
+        neighbours = [(x, y + 1), (x, y - 1), (x - 1, y), (x + 1, y)]
+        return [1.0 if self._is_impassable(nx, ny) else 0.0 for nx, ny in neighbours]
+
     def _get_obs(self) -> np.ndarray:
         steps_remaining = self.max_steps - self.steps
         return np.array(
-            [self.position[0], self.position[1], self.goal[0], self.goal[1], steps_remaining],
+            [
+                self.position[0],
+                self.position[1],
+                self.goal[0],
+                self.goal[1],
+                steps_remaining,
+                *self._sensor_flags(),
+            ],
             dtype=np.float32,
         )
 
@@ -105,6 +156,7 @@ class DroneEnv(gym.Env):
     # ------------------------------------------------------------------
     def reset(self, *, seed: int | None = None, options: dict | None = None) -> Tuple[np.ndarray, Dict[str, Any]]:
         super().reset(seed=seed)
+        self.obstacles = self._generate_obstacles()
         self.position = np.zeros(2, dtype=np.float32)
         self.goal = np.array([self.grid_size - 1, self.grid_size - 1], dtype=np.float32)
         self.steps = 0
@@ -115,24 +167,38 @@ class DroneEnv(gym.Env):
     def step(self, action: int) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
         self.steps += 1
 
-        # Move drone
+        # Where the action would take the drone. Edges clamp, so a move into a
+        # wall is absorbed rather than rejected.
+        x, y = float(self.position[0]), float(self.position[1])
         if action == 1:  # up
-            self.position[1] = min(self.grid_size - 1, self.position[1] + 1)
+            y = min(self.grid_size - 1, y + 1)
         elif action == 2:  # down
-            self.position[1] = max(0, self.position[1] - 1)
+            y = max(0, y - 1)
         elif action == 3:  # left
-            self.position[0] = max(0, self.position[0] - 1)
+            x = max(0, x - 1)
         elif action == 4:  # right
-            self.position[0] = min(self.grid_size - 1, self.position[0] + 1)
+            x = min(self.grid_size - 1, x + 1)
         # action 0 -> hover
+
+        # An obstacle refuses the move outright: the drone stays where it was.
+        collided = self._is_obstacle(int(x), int(y))
+        if not collided:
+            self.position[0], self.position[1] = x, y
 
         obs = self._get_obs()
 
         terminated = bool(np.array_equal(self.position, self.goal))
-        reward = 10.0 if terminated else -1.0
+        if terminated:
+            reward = 10.0
+        else:
+            # A collision costs more than a wasted step, otherwise there is no
+            # gradient telling the policy to route around anything.
+            reward = -2.0 if collided else -1.0
         truncated = bool(self.steps >= self.max_steps)
 
         info: Dict[str, Any] = {}
+        if collided:
+            info["collision"] = True
         errors = self.validator.validate(obs, action, reward)
         if errors:
             info["integrity_errors"] = errors

--- a/tests/test_obstacles.py
+++ b/tests/test_obstacles.py
@@ -1,0 +1,106 @@
+"""
+Obstacle tests.
+
+obstacle_density sat in configs/env.yaml being read into an attribute and never
+used. These cover the behaviour that field now buys: obstacles are generated at
+roughly the configured rate, they refuse movement, they cost more than an
+ordinary step, and the drone can sense them before walking into them.
+"""
+
+import numpy as np
+import pytest
+
+from env.drone_env import DroneEnv
+
+
+@pytest.fixture
+def env():
+    e = DroneEnv()
+    try:
+        yield e
+    finally:
+        e.close()
+
+
+def test_observation_is_nine_dimensional_and_in_space(env):
+    obs, _ = env.reset(seed=0)
+    assert obs.shape == (9,)
+    assert env.observation_space.contains(obs)
+
+
+def test_start_and_goal_are_never_blocked(env):
+    """A blocked start is meaningless and a blocked goal is unwinnable."""
+    for seed in range(25):
+        env.reset(seed=seed)
+        assert not env.obstacles[0, 0]
+        assert not env.obstacles[env.grid_size - 1, env.grid_size - 1]
+
+
+def test_obstacle_rate_tracks_the_configured_density(env):
+    """Averaged over seeds, the draw should sit near obstacle_density."""
+    rates = []
+    for seed in range(30):
+        env.reset(seed=seed)
+        rates.append(env.obstacles.mean())
+    assert env.obstacle_density == pytest.approx(0.1)
+    assert np.mean(rates) == pytest.approx(0.1, abs=0.03)
+
+
+def test_same_seed_gives_the_same_obstacles(env):
+    env.reset(seed=7)
+    first = env.obstacles.copy()
+    env.reset(seed=7)
+    assert np.array_equal(first, env.obstacles)
+
+
+def test_moving_into_an_obstacle_is_refused_and_costs_extra(env):
+    """Position is unchanged, the step is flagged, and it costs more than a plain move."""
+    env.reset(seed=0)
+    # Plant an obstacle directly above the drone, then try to move up.
+    env.obstacles[:] = False
+    env.obstacles[0, 1] = True
+    before = env.position.copy()
+
+    obs, reward, terminated, truncated, info = env.step(1)  # up
+
+    assert np.array_equal(env.position, before)
+    assert info.get("collision") is True
+    assert reward == -2.0
+    assert not terminated
+
+
+def test_a_clear_move_is_not_flagged_and_costs_one(env):
+    env.reset(seed=0)
+    env.obstacles[:] = False
+    before = env.position.copy()
+
+    obs, reward, terminated, truncated, info = env.step(1)  # up
+
+    assert not np.array_equal(env.position, before)
+    assert "collision" not in info
+    assert reward == -1.0
+
+
+def test_sensor_flags_report_adjacent_obstacles(env):
+    """The four trailing observation values are up, down, left, right."""
+    env.reset(seed=0)
+    env.obstacles[:] = False
+    env.obstacles[0, 1] = True  # directly above the start at (0, 0)
+
+    obs = env._get_obs()
+    up, down, left, right = obs[5], obs[6], obs[7], obs[8]
+
+    assert up == 1.0        # the obstacle
+    assert down == 1.0      # the grid edge reads as impassable too
+    assert left == 1.0      # edge
+    assert right == 0.0     # clear
+
+
+def test_zero_density_produces_no_obstacles(tmp_path):
+    """A density of zero must leave the grid completely clear."""
+    config = tmp_path / "env.yaml"
+    config.write_text("grid_size: 10\nnum_drones: 1\nobstacle_density: 0.0\nmax_steps: 50\n")
+    e = DroneEnv(str(config))
+    e.reset(seed=3)
+    assert not e.obstacles.any()
+    e.close()


### PR DESCRIPTION
## Problem

- `obstacle_density: 0.1` has sat in `configs/env.yaml` since the first commit, read into an attribute and never used. The grid was always empty.
- Simply blocking movement would not have been worth much on its own. The observation exposed no way to perceive an obstacle, so a policy could only discover one by walking into it. Avoidance would not have been learnable, and obstacles would have been a tax on a blind policy rather than something to solve.

## Fix

- **Obstacles are drawn at `reset()`** from the seeded RNG, so the same seed reproduces the same grid. Start and goal cells are always cleared: a blocked start is meaningless, a blocked goal is unwinnable, and neither is left to chance.
- **Observation grows from 5 to 9 values.** The last four are blocked flags for the four moves, in action order. A grid edge reads as blocked too, since from the drone's point of view a wall and an obstacle are the same fact.
- **A move into an obstacle is refused**, leaving position unchanged, and costs `-2.0` against `-1.0` for an ordinary step. If a collision cost the same as a step, nothing would point the policy away from it.
- Nothing downstream needed changing by hand: `PPOPolicy` sizes its input from `observation_space`, and the `/predict` length check reads the same shape.

## Tests

Verified by running, not by reading.

- [x] Unit: observation is 9-dimensional and inside `observation_space`
- [x] Edge cases: start and goal are never blocked, checked across 25 seeds
- [x] Unit: obstacle rate tracks the configured `0.1` density, averaged over 30 seeds
- [x] Unit: the same seed reproduces the same obstacle grid
- [x] Unit: a move into an obstacle leaves position unchanged, sets `info["collision"]`, and returns `-2.0`; a clear move returns `-1.0` and sets no flag
- [x] Unit: sensor flags report adjacent obstacles and grid edges in up, down, left, right order
- [x] Edge cases: a density of `0.0` produces a completely clear grid
- [x] Integration: full suite **15 to 23 tests**, 85 percent coverage, green in the Docker image
- [x] Happy path: training completes with exit 0 and zero drift, zero hallucination over the run
- [x] Automated UI sanity: live container returns 200 with `{"action":4,"action_name":"right"}` for a 9-value body, and a clear 422 for an old 5-value body

🤖 Generated with [Claude Code](https://claude.com/claude-code)
