### PR TITLE
Implement multiple drones with MAPF conflict resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 <img alt="python 3.10" src="https://img.shields.io/badge/python-3.10-dfe3e0?style=flat-square&labelColor=0d1410">
 <img alt="PPO in PyTorch 2.2.2" src="https://img.shields.io/badge/PPO-PyTorch_2.2.2-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="env gymnasium" src="https://img.shields.io/badge/env-gymnasium-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="tests 23 passing" src="https://img.shields.io/badge/tests-23_passing-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="coverage 85 percent" src="https://img.shields.io/badge/coverage-85%25-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="tests 33 passing" src="https://img.shields.io/badge/tests-33_passing-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="coverage 87 percent" src="https://img.shields.io/badge/coverage-87%25-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="license Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-8f9491?style=flat-square&labelColor=0d1410">
 
 <br/><br/>
@@ -107,9 +107,10 @@ The control loop is small. The validators hang off both halves of it, and everyt
                     |
   ENVIRONMENT  DroneEnv (gymnasium)
                     |  reset() / step(action)  ->  obs, reward, terminated, truncated, info
-                    |  observation   Box(9)        x, y, goal_x, goal_y, steps_remaining,
-                    |                              blocked up/down/left/right
-                    |  action        Discrete(5)   hover, up, down, left, right (clamped)
+                    |  observation   Box(N, 9)     per drone: x, y, goal_x, goal_y,
+                    |                              steps_remaining, blocked u/d/l/r
+                    |  action        MultiDiscrete one move per drone
+                    |  conflicts     vertex, swap and stationary, all refused
                     v
   AGENT        PPOAgent (PyTorch)
                     |  PPOPolicy     shared Linear(5,64)+ReLU  ->  policy head (5), value head (1)
@@ -137,7 +138,7 @@ The original hand-drawn design panoramas are kept in [`architecture/`](architect
 
 A grid world, deliberately small, so the validator layer is the thing under test rather than the control problem.
 
-**Observation**, a `Box` of shape `(9,)`, `float32`:
+**Observation**, a `Box` of shape `(num_drones, 9)`, `float32`. One row per drone, so a single drone is the degenerate case of the same shape:
 
 | index | field | range |
 |---|---|---|
@@ -146,11 +147,13 @@ A grid world, deliberately small, so the validator layer is the thing under test
 | 4 | `steps_remaining` | `0` to `max_steps` |
 | 5 to 8 | blocked up, down, left, right | `0` or `1` |
 
+The blocked flags fold three facts into one signal: a wall, an obstacle, and another drone all read as impassable, because from a drone's point of view they are the same fact.
+
 The last four are local sensing, in action order. They exist because blocking movement alone is useless: a drone that cannot see an obstacle before hitting it cannot learn to route around one, so obstacles would be nothing but a tax on a blind policy. A grid edge reads as blocked too.
 
 Bounds are per-dimension, for the reason described above. One scalar bound cannot describe both a coordinate and a step counter.
 
-**Action**, `Discrete(5)`:
+**Action**, `MultiDiscrete([5] * num_drones)`, one move per drone:
 
 | index | action | effect |
 |---|---|---|
@@ -162,7 +165,7 @@ Bounds are per-dimension, for the reason described above. One scalar bound canno
 
 Moves clamp at the grid edge, so an illegal move is absorbed rather than rejected. `action_map` carries the human-readable names.
 
-**Reward**: `+10.0` on reaching the goal, `-2.0` for a step that runs into an obstacle, `-1.0` otherwise. `terminated` on goal, `truncated` at `max_steps`. The agent starts at the origin and the goal sits at the far corner, so the shortest unobstructed path under this config is 38 moves. A collision costs more than a wasted step; if it cost the same, nothing would tell the policy to route around anything.
+**Reward**: summed across the fleet. Per drone, `+10.0` at its goal, `-2.0` for a refused move, `-1.0` otherwise. `terminated` on goal, `truncated` at `max_steps`. The agent starts at the origin and the goal sits at the far corner, so the shortest unobstructed path under this config is 38 moves. A collision costs more than a wasted step; if it cost the same, nothing would tell the policy to route around anything.
 
 That shipped reward is deliberately spiky: the goal bonus is an event, not a gradient. It is the top left quadrant below, and it is the cheapest thing that works for a single drone. Once more than one drone shares the grid, the quadrant matters, because a spike is exactly what a policy learns to farm.
 
@@ -245,7 +248,7 @@ Only one config file is actually read by the code today.
 ```yaml
 # configs/env.yaml, the one that is loaded
 grid_size: 20
-num_drones: 10          # read into an attribute, never used
+num_drones: 10          # fleet size; each gets its own start and goal
 obstacle_density: 0.1   # obstacle rate per cell, start and goal always clear
 max_steps: 200
 ```
@@ -280,12 +283,12 @@ Worth reading before the deployment sections. The repository name is older than 
 | Docker image, Compose, Kubernetes manifests, Prometheus and Grafana config | **Implemented** as configuration |
 | `/predict` end to end | **Implemented**. Takes the 5-number observation vector |
 | Hyperparameters from `configs/train.yaml` | **Implemented**. Loaded and applied to `PPOAgent` |
-| Multi-agent, more than one drone | **Not implemented**. `num_drones` is read into an attribute and never used; the env tracks a single position vector |
-| MAPF, multi-agent path finding | **Not implemented**. No conflict resolution, no reservation table, no joint planner |
+| Multi-agent, more than one drone | **Implemented**. `num_drones` sets the fleet; shared policy weights across drones |
+| MAPF, multi-agent path finding | **Implemented**. Vertex, swap and stationary conflicts detected and refused each step |
 | Obstacles | **Implemented**. Drawn from `obstacle_density`, refuse movement, and are locally sensed |
 | Ingestion, Preprocess and Prediction agents; Safety Controller; Supervisor | **Design only**, described in [`architecture/summary.md`](architecture/summary.md), no code in `src/` |
 
-The multi-agent and MAPF pieces are the roadmap the name points at, not a description of `src/`.
+The name now describes the code: multiple drones share one grid, see each other, and have their conflicting moves refused. What remains is the Safety Controller, the first component that would be allowed to veto rather than only report.
 
 ### The designed system
 
@@ -337,11 +340,10 @@ Full written spec in [`architecture/low_level_design.txt`](architecture/low_leve
 
 Roughly in dependency order:
 
-1. Multiple drones: a per-drone observation and action, and a reward that prices collisions.
-2. MAPF proper: conflict detection between planned paths, then a resolution strategy.
-3. Safety Controller, the first component allowed to veto rather than only report.
+1. Safety Controller, the first component allowed to veto rather than only report.
+2. A learned conflict policy: today conflicts are refused, which is correct but blunt. Yielding by priority or by remaining distance would be a real coordination signal.
 
-Done: obstacles are generated and sensed, the `/predict` contract now takes the 5-number observation vector and is covered by tests that do not stub the agent, and `configs/train.yaml` is loaded and applied rather than silently discarded.
+Done: multiple drones share the grid with vertex, swap and stationary conflicts refused, obstacles are generated and sensed, the `/predict` contract now takes the 5-number observation vector and is covered by tests that do not stub the agent, and `configs/train.yaml` is loaded and applied rather than silently discarded.
 
 ---
 
@@ -397,8 +399,8 @@ curl http://localhost:8000/healthz
 ```bash
 curl -X POST http://localhost:8000/predict \
   -H "Content-Type: application/json" \
-  -d '{"state": [0, 0, 19, 19, 200, 1, 1, 1, 0]}'
-# {"action":4,"action_name":"right"}
+  -d '{"state": [[0, 0, 19, 19, 200, 1, 1, 1, 0]]}'   # one row per drone
+# {"actions":[4],"action_names":["right"]}
 ```
 
 ---
@@ -430,9 +432,10 @@ pytest --cov=src --cov-report=term-missing
 | `tests/test_api.py` | `/predict` against the real agent: a legal action, and 422 for a wrong-length or mapping body |
 | `tests/test_main_config.py` | `--config` is parsed, applied to `PPOAgent`, and unknown flags exit non-zero |
 | `tests/test_obstacles.py` | Density, determinism, refused moves, the collision penalty, and the sensor flags |
+| `tests/test_multi_drone.py` | Fleet contract, distinct starts and goals, and the three conflict kinds |
 | `tests/test_load.py` | Repeated stepping under pressure |
 
-Current state: 23 passing, 85 percent line coverage.
+Current state: 33 passing, 87 percent line coverage.
 
 ---
 

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -52,7 +52,7 @@
 <text x="34" y="88" fill="#f2f5f3" font-size="34" font-weight="700" letter-spacing="0.4">Architecture</text>
 <text x="34" y="118" fill="#939a95" font-size="19">One control loop, top to bottom. The bright band is the part that watches.</text>
 <rect x="700" y="30" width="2" height="62" fill="#333d36"/>
-<text x="946" y="52" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">9 obs dims / 5 actions</text>
+<text x="946" y="52" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">10 drones / 9 dims each</text>
 <text x="946" y="78" fill="#979e99" font-size="17" text-anchor="end" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">grid 20x20 / 200 steps</text>
 
 <text x="62" y="170" fill="#6faa85" font-size="16" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">01</text>
@@ -80,9 +80,9 @@
 <rect x="526" y="372" width="420" height="152" fill="url(#panel)" stroke="#47514a" stroke-width="1.5"/>
 <rect x="538" y="372.7" width="396" height="1.4" fill="url(#edge)"/>
 <text x="548" y="408" fill="#ecefed" font-size="22" font-weight="700">spaces</text>
-<text x="548" y="442" fill="#a5aca7" font-size="19">observation Box(9): x, y, goal x, goal y,</text>
-<text x="548" y="470" fill="#a5aca7" font-size="19">steps remaining, plus 4 sensor flags</text>
-<text x="548" y="504" fill="#a5aca7" font-size="19">action Discrete(5), edge clamped</text>
+<text x="548" y="442" fill="#a5aca7" font-size="19">observation Box(10, 9), one row per drone</text>
+<text x="548" y="470" fill="#a5aca7" font-size="19">action MultiDiscrete, one move each</text>
+<text x="548" y="504" fill="#a5aca7" font-size="19">conflicts refused: vertex, swap, stationary</text>
 
 <path d="M 482 448 L 518 448" stroke="#949a96" stroke-width="2" fill="none" marker-end="url(#a)"/>
 

--- a/src/agents/ppo_agent.py
+++ b/src/agents/ppo_agent.py
@@ -80,8 +80,12 @@ class PPOAgent:
         self.eps_clip = eps_clip # PPO clipping parameter
         self.epochs = epochs     # policy update iterations
 
-        obs_dim = env.observation_space.shape[0]  # 5 features
-        act_dim = env.action_space.n              # 5 actions
+        # One row of features per drone, and the same move set for each. The
+        # policy weights are shared across drones: a single trunk is applied to
+        # every row, so the network size does not grow with the fleet and a
+        # lesson learned by one drone is available to all of them.
+        obs_dim = int(env.observation_space.shape[-1])
+        act_dim = int(env.action_space.nvec[0]) if hasattr(env.action_space, "nvec") else int(env.action_space.n)
 
         # Initialize policy network and optimizer
         self.policy = PPOPolicy(obs_dim, act_dim)
@@ -95,18 +99,20 @@ class PPOAgent:
         Pick an action from the current policy.
         -> During training, we sample from the distribution (exploration).
         """
-        state = torch.tensor(state, dtype=torch.float32).unsqueeze(0)
+        state = torch.tensor(np.asarray(state), dtype=torch.float32)
         probs, value = self.policy(state)
         m = Categorical(probs)
         action = m.sample()
 
-        # Integrity check
-        errors = self.validator.validate(probs.squeeze(), value.squeeze(), action.item())
+        # Integrity check. One log probability per drone, summed, because the
+        # fleet's move is the joint event and PPO's ratio is over that.
+        actions = action.detach().numpy()
+        errors = self.validator.validate(probs, value.mean(), actions)
         if errors:
             for e in errors:
                 print(f"[Integrity Warning] {e['type']} on {e['field']}: {e['msg']}")
 
-        return action.item(), m.log_prob(action)
+        return actions, m.log_prob(action).sum()
 
     def train(self, num_episodes=100):
         """
@@ -148,17 +154,22 @@ class PPOAgent:
             # Policy update for several epochs
             for _ in range(self.epochs):
                 states_t = torch.tensor(np.array(states), dtype=torch.float32)
-                actions_t = torch.tensor(actions, dtype=torch.long)
+                actions_t = torch.tensor(np.array(actions), dtype=torch.long)
                 old_log_probs = torch.stack(log_probs)
 
                 # Forward pass
                 probs, values = self.policy(states_t)
                 m = Categorical(probs)
-                new_log_probs = m.log_prob(actions_t)
+                # Sum across drones so each timestep has one joint log probability.
+                new_log_probs = m.log_prob(actions_t).sum(dim=-1)
                 entropy = m.entropy().mean()  # encourages exploration
 
+                # One scalar baseline per timestep: the fleet's reward is a team
+                # total, so the critic is averaged over drones to match it.
+                state_values = values.squeeze(-1).mean(dim=-1)
+
                 # Advantage = return - baseline
-                advantages = discounted - values.squeeze()
+                advantages = discounted - state_values
                 advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
 
                 # PPO surrogate loss
@@ -167,7 +178,7 @@ class PPOAgent:
                 surr2 = torch.clamp(ratio, 1 - self.eps_clip, 1 + self.eps_clip) * advantages
 
                 # Value loss (MSE)
-                value_loss = (discounted - values.squeeze()) ** 2
+                value_loss = (discounted - state_values) ** 2
 
                 # Total loss = policy + value - entropy
                 loss = -torch.min(surr1, surr2).mean() \
@@ -194,12 +205,12 @@ class PPOAgent:
         Greedy action selection (for inference).
         -> Use after training when running in production.
         """
-        state = torch.tensor(state, dtype=torch.float32).unsqueeze(0)
+        state = torch.tensor(np.asarray(state), dtype=torch.float32)
         probs, value = self.policy(state)
-        action = torch.argmax(probs, dim=-1).item()
+        action = torch.argmax(probs, dim=-1).detach().numpy()
 
         # Integrity check
-        errors = self.validator.validate(probs.squeeze(), value.squeeze(), action)
+        errors = self.validator.validate(probs, value.mean(), action)
         if errors:
             for e in errors:
                 print(f"[Integrity Warning] {e['type']} on {e['field']}: {e['msg']}")

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -31,13 +31,14 @@ from src.agents.ppo_agent import PPOAgent
 class StateInput(BaseModel):
     """Schema for the prediction request body.
 
-    ``state`` is one environment observation, flat and in the order the
-    environment emits it: ``[x, y, goal_x, goal_y, steps_remaining]``. It is a
-    list of numbers rather than a mapping because that is what the policy
-    consumes; ``PPOAgent.predict`` builds a tensor straight from it.
+    ``state`` is one environment observation: a row per drone, each row being
+    ``[x, y, goal_x, goal_y, steps_remaining, blocked_up, blocked_down,
+    blocked_left, blocked_right]``. It is a list of rows rather than a mapping
+    because that is what the policy consumes; ``PPOAgent.predict`` builds a
+    tensor straight from it.
     """
 
-    state: List[float]
+    state: List[List[float]]
 
 
 # -------------------------------------------------
@@ -95,21 +96,27 @@ def predict(payload: StateInput):
     """
     Accepts a payload matching :class:`StateInput` and returns the agent's action.
 
-    Example request:  { "state": [0, 0, 19, 19, 200] }
-    Example response: { "action": 4, "action_name": "right" }
+    Example request:  { "state": [[0, 0, 19, 19, 200, 1, 1, 1, 0]] }
+    Example response: { "actions": [4], "action_names": ["right"] }
 
-    The action is returned both ways on purpose. The index is what the
-    environment's ``step()`` accepts; the name is what a human reads in a log.
+    Actions are returned both ways on purpose. The indices are what the
+    environment's ``step()`` accepts; the names are what a human reads in a log.
     """
     logger.info("Received predict request")
 
-    expected = int(env.observation_space.shape[0])
-    if len(payload.state) != expected:
-        # A wrong-length observation is a client error, not a server fault, so
-        # it is rejected before it can reach the policy as an opaque failure.
+    rows, cols = env.observation_space.shape
+    # A malformed observation is a client error, not a server fault, so it is
+    # rejected before it can reach the policy as an opaque tensor failure.
+    if len(payload.state) != rows:
         raise HTTPException(
             status_code=422,
-            detail=f"state must have exactly {expected} values, got {len(payload.state)}",
+            detail=f"state must have exactly {rows} rows, one per drone, got {len(payload.state)}",
+        )
+    bad = [i for i, row in enumerate(payload.state) if len(row) != cols]
+    if bad:
+        raise HTTPException(
+            status_code=422,
+            detail=f"each row must have exactly {cols} values; row {bad[0]} has {len(payload.state[bad[0]])}",
         )
 
     try:
@@ -117,7 +124,8 @@ def predict(payload: StateInput):
     except Exception as e:
         # Wrap raw exceptions in a clean APIError
         raise APIError(f"Prediction failed: {str(e)}", status_code=500)
-    return {"action": action, "action_name": env.action_map[action]}
+    actions = [int(a) for a in action]
+    return {"actions": actions, "action_names": [env.action_map[a] for a in actions]}
 
 
 @app.get("/metrics")

--- a/src/env/drone_env.py
+++ b/src/env/drone_env.py
@@ -1,4 +1,4 @@
-"""Drone environment for reinforcement learning."""
+"""Multi-drone environment for reinforcement learning and path finding."""
 
 from __future__ import annotations
 
@@ -16,9 +16,18 @@ except Exception:  # pragma: no cover
 
 from integrity_validators import IntegrityValidator
 
+# Observation values per drone, before the four sensor flags.
+_BASE_FEATURES = 5
+_SENSOR_FLAGS = 4
+_FEATURES_PER_DRONE = _BASE_FEATURES + _SENSOR_FLAGS
+
 
 class DroneEnv(gym.Env):
-    """Simple grid-based drone environment.
+    """Grid world holding one or more drones.
+
+    Every drone is described by the same nine features, so the observation is
+    ``(num_drones, 9)`` and the action is one discrete move per drone. A single
+    drone is simply the degenerate case of the same shape.
 
     Parameters
     ----------
@@ -32,53 +41,45 @@ class DroneEnv(gym.Env):
         super().__init__()
         self.config = self._load_config(config_path)
         self.grid_size: int = int(self.config.get("grid_size", 10))
-        self.num_drones: int = int(self.config.get("num_drones", 1))
+        self.num_drones: int = max(1, int(self.config.get("num_drones", 1)))
         self.obstacle_density: float = float(self.config.get("obstacle_density", 0.0))
         self.max_steps: int = int(self.config.get("max_steps", 100))
 
-        # Observation: [x, y, goal_x, goal_y, steps_remaining,
-        #               blocked_up, blocked_down, blocked_left, blocked_right]
-        # Bounds are per-dimension: the coordinates are clamped to the grid, while
-        # steps_remaining counts down from max_steps. A single scalar bound would
-        # put every steps_remaining > grid_size outside the declared space.
-        # The four trailing flags are local sensing. Without them a drone cannot
-        # see an obstacle before hitting it, so avoidance is not learnable and the
-        # obstacles would only ever be a tax on a blind policy.
+        # Per drone: [x, y, goal_x, goal_y, steps_remaining,
+        #             blocked_up, blocked_down, blocked_left, blocked_right]
+        # Bounds are per-dimension. The coordinates are clamped to the grid while
+        # steps_remaining counts down from max_steps, so one scalar bound cannot
+        # describe both. The trailing flags are local sensing: without them a
+        # drone cannot see an obstacle or a neighbour before moving into one.
+        row_high = np.array(
+            [
+                self.grid_size - 1,
+                self.grid_size - 1,
+                self.grid_size - 1,
+                self.grid_size - 1,
+                self.max_steps,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+            ],
+            dtype=np.float32,
+        )
         self.observation_space = spaces.Box(
-            low=np.zeros(9, dtype=np.float32),
-            high=np.array(
-                [
-                    self.grid_size - 1,
-                    self.grid_size - 1,
-                    self.grid_size - 1,
-                    self.grid_size - 1,
-                    self.max_steps,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                ],
-                dtype=np.float32,
-            ),
+            low=np.zeros((self.num_drones, _FEATURES_PER_DRONE), dtype=np.float32),
+            high=np.tile(row_high, (self.num_drones, 1)),
             dtype=np.float32,
         )
 
-        # Actions: 0 hover, 1 up, 2 down, 3 left, 4 right
-        self.action_space = spaces.Discrete(5)
-        self.action_map = {
-            0: "hover",
-            1: "up",
-            2: "down",
-            3: "left",
-            4: "right",
-        }
+        # One move per drone: 0 hover, 1 up, 2 down, 3 left, 4 right.
+        self.action_space = spaces.MultiDiscrete([5] * self.num_drones)
+        self.action_map = {0: "hover", 1: "up", 2: "down", 3: "left", 4: "right"}
 
         self.validator = IntegrityValidator(self.action_space, self.observation_space)
 
-        self.position = np.zeros(2, dtype=np.float32)
-        self.goal = np.array([self.grid_size - 1, self.grid_size - 1], dtype=np.float32)
+        self.positions = np.zeros((self.num_drones, 2), dtype=np.float32)
+        self.goals = np.zeros((self.num_drones, 2), dtype=np.float32)
         self.steps = 0
-        # Populated on reset, once the seeded RNG exists.
         self.obstacles = np.zeros((self.grid_size, self.grid_size), dtype=bool)
 
     # ------------------------------------------------------------------
@@ -104,52 +105,88 @@ class DroneEnv(gym.Env):
             return data
 
     def _generate_obstacles(self) -> np.ndarray:
-        """Draw a fresh obstacle grid from the seeded RNG.
-
-        The start and goal cells are always cleared. A blocked start would make
-        the episode meaningless, and a blocked goal would make it unwinnable, so
-        neither is left to chance.
-        """
+        """Draw a fresh obstacle grid from the seeded RNG."""
         grid = np.zeros((self.grid_size, self.grid_size), dtype=bool)
         if self.obstacle_density <= 0:
             return grid
+        return self.np_random.random((self.grid_size, self.grid_size)) < self.obstacle_density
 
-        grid = self.np_random.random((self.grid_size, self.grid_size)) < self.obstacle_density
-        grid[0, 0] = False
-        grid[self.grid_size - 1, self.grid_size - 1] = False
-        return grid
+    def _free_cells(self) -> np.ndarray:
+        """Every cell not holding an obstacle, as an (n, 2) array."""
+        xs, ys = np.where(~self.obstacles)
+        return np.stack([xs, ys], axis=1)
+
+    def _place(self) -> None:
+        """Choose distinct start and goal cells for every drone.
+
+        Starts must be distinct from each other, or two drones would begin
+        stacked in one cell. Goals must be distinct too, or drones would be
+        rewarded for crowding a single square.
+        """
+        free = self._free_cells()
+        needed = 2 * self.num_drones
+        if len(free) < needed:
+            raise ValueError(
+                f"grid has {len(free)} free cells but {self.num_drones} drones need {needed}; "
+                "lower obstacle_density or raise grid_size"
+            )
+        chosen = self.np_random.choice(len(free), size=needed, replace=False)
+        picks = free[chosen]
+        self.positions = picks[: self.num_drones].astype(np.float32)
+        self.goals = picks[self.num_drones :].astype(np.float32)
+
+    def _occupied(self) -> set:
+        return {(int(p[0]), int(p[1])) for p in self.positions}
 
     def _is_obstacle(self, x: int, y: int) -> bool:
-        """True when the cell holds an obstacle. Out of bounds is not an obstacle."""
         if not (0 <= x < self.grid_size and 0 <= y < self.grid_size):
             return False
         return bool(self.obstacles[x, y])
 
-    def _is_impassable(self, x: int, y: int) -> bool:
-        """What the drone's local sensor reports: a wall reads the same as an obstacle."""
+    def _is_impassable(self, x: int, y: int, occupied: set) -> bool:
+        """What a drone's sensor reports: wall, obstacle and neighbour all read alike."""
         if not (0 <= x < self.grid_size and 0 <= y < self.grid_size):
             return True
-        return bool(self.obstacles[x, y])
+        if self.obstacles[x, y]:
+            return True
+        return (x, y) in occupied
 
-    def _sensor_flags(self) -> list:
-        """Blocked flags for the four moves, in action order: up, down, left, right."""
-        x, y = int(self.position[0]), int(self.position[1])
+    def _sensor_flags(self, index: int, occupied: set) -> list:
+        """Blocked flags for one drone, in action order: up, down, left, right."""
+        x, y = int(self.positions[index][0]), int(self.positions[index][1])
+        others = occupied - {(x, y)}
         neighbours = [(x, y + 1), (x, y - 1), (x - 1, y), (x + 1, y)]
-        return [1.0 if self._is_impassable(nx, ny) else 0.0 for nx, ny in neighbours]
+        return [1.0 if self._is_impassable(nx, ny, others) else 0.0 for nx, ny in neighbours]
 
     def _get_obs(self) -> np.ndarray:
         steps_remaining = self.max_steps - self.steps
-        return np.array(
-            [
-                self.position[0],
-                self.position[1],
-                self.goal[0],
-                self.goal[1],
-                steps_remaining,
-                *self._sensor_flags(),
-            ],
-            dtype=np.float32,
-        )
+        occupied = self._occupied()
+        rows = []
+        for i in range(self.num_drones):
+            rows.append(
+                [
+                    self.positions[i][0],
+                    self.positions[i][1],
+                    self.goals[i][0],
+                    self.goals[i][1],
+                    steps_remaining,
+                    *self._sensor_flags(i, occupied),
+                ]
+            )
+        return np.array(rows, dtype=np.float32)
+
+    def _target(self, index: int, action: int) -> Tuple[float, float]:
+        """Where one action would take one drone, clamped at the grid edge."""
+        x, y = float(self.positions[index][0]), float(self.positions[index][1])
+        if action == 1:
+            y = min(self.grid_size - 1, y + 1)
+        elif action == 2:
+            y = max(0, y - 1)
+        elif action == 3:
+            x = max(0, x - 1)
+        elif action == 4:
+            x = min(self.grid_size - 1, x + 1)
+        return x, y
 
     # ------------------------------------------------------------------
     # Gym API
@@ -157,49 +194,81 @@ class DroneEnv(gym.Env):
     def reset(self, *, seed: int | None = None, options: dict | None = None) -> Tuple[np.ndarray, Dict[str, Any]]:
         super().reset(seed=seed)
         self.obstacles = self._generate_obstacles()
-        self.position = np.zeros(2, dtype=np.float32)
-        self.goal = np.array([self.grid_size - 1, self.grid_size - 1], dtype=np.float32)
+        self._place()
         self.steps = 0
-        obs = self._get_obs()
-        info: Dict[str, Any] = {}
-        return obs, info
+        return self._get_obs(), {}
 
-    def step(self, action: int) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
+    def step(self, action) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
+        """Advance every drone by one move, resolving conflicts by refusal.
+
+        Three kinds of conflict are refused rather than resolved by priority,
+        because a priority rule would quietly teach the policy that some drones
+        always win: two drones claiming one cell, two drones swapping cells, and
+        a drone moving into a cell whose occupant is staying put.
+        """
         self.steps += 1
+        actions = np.atleast_1d(np.asarray(action)).astype(int).ravel()
+        if actions.size != self.num_drones:
+            raise ValueError(f"expected {self.num_drones} actions, got {actions.size}")
 
-        # Where the action would take the drone. Edges clamp, so a move into a
-        # wall is absorbed rather than rejected.
-        x, y = float(self.position[0]), float(self.position[1])
-        if action == 1:  # up
-            y = min(self.grid_size - 1, y + 1)
-        elif action == 2:  # down
-            y = max(0, y - 1)
-        elif action == 3:  # left
-            x = max(0, x - 1)
-        elif action == 4:  # right
-            x = min(self.grid_size - 1, x + 1)
-        # action 0 -> hover
+        current = [(int(p[0]), int(p[1])) for p in self.positions]
+        intended = []
+        collided = [False] * self.num_drones
 
-        # An obstacle refuses the move outright: the drone stays where it was.
-        collided = self._is_obstacle(int(x), int(y))
-        if not collided:
-            self.position[0], self.position[1] = x, y
+        # Pass 1: an obstacle refuses the move outright.
+        for i in range(self.num_drones):
+            tx, ty = self._target(i, int(actions[i]))
+            if self._is_obstacle(int(tx), int(ty)):
+                intended.append(current[i])
+                collided[i] = True
+            else:
+                intended.append((int(tx), int(ty)))
 
-        obs = self._get_obs()
+        # Pass 2: drone against drone, repeated until nothing else gives way.
+        for _ in range(self.num_drones + 1):
+            changed = False
+            for i in range(self.num_drones):
+                if intended[i] == current[i]:
+                    continue
+                for j in range(self.num_drones):
+                    if i == j:
+                        continue
+                    # A drone that is staying put covers the stationary case too:
+                    # its intended cell is its current cell, so "same cell" catches
+                    # a mover walking into it.
+                    j_is_moving = intended[j] != current[j]
+                    same_cell = intended[i] == intended[j]
+                    swapping = intended[i] == current[j] and intended[j] == current[i]
+                    if same_cell or swapping:
+                        intended[i] = current[i]
+                        collided[i] = True
+                        # Only fault the other drone if it was also trying to move.
+                        # Penalising one for holding its ground would teach the
+                        # policy that hovering is risky, which is the opposite of
+                        # what a yielding manoeuvre should cost.
+                        if j_is_moving:
+                            intended[j] = current[j]
+                            collided[j] = True
+                        changed = True
+                        break
+            if not changed:
+                break
 
-        terminated = bool(np.array_equal(self.position, self.goal))
-        if terminated:
-            reward = 10.0
-        else:
-            # A collision costs more than a wasted step, otherwise there is no
-            # gradient telling the policy to route around anything.
-            reward = -2.0 if collided else -1.0
+        self.positions = np.array(intended, dtype=np.float32)
+
+        at_goal = np.all(self.positions == self.goals, axis=1)
+        rewards = np.where(at_goal, 10.0, np.where(collided, -2.0, -1.0))
+        reward = float(rewards.sum())
+
+        terminated = bool(at_goal.all())
         truncated = bool(self.steps >= self.max_steps)
 
-        info: Dict[str, Any] = {}
-        if collided:
-            info["collision"] = True
-        errors = self.validator.validate(obs, action, reward)
+        obs = self._get_obs()
+        info: Dict[str, Any] = {"at_goal": int(at_goal.sum())}
+        if any(collided):
+            info["collisions"] = int(sum(collided))
+
+        errors = self.validator.validate(obs, actions, reward)
         if errors:
             info["integrity_errors"] = errors
 

--- a/src/integrity_validators.py
+++ b/src/integrity_validators.py
@@ -32,6 +32,18 @@ class IntegrityValidator:
         self.action_space = action_space
         self.observation_space = observation_space
 
+    def _as_action(self, action):
+        """Shape an action the way its space expects it.
+
+        A MultiDiscrete space holds one move per drone and wants an integer
+        vector; a Discrete space wants a single integer. Casting a vector with
+        ``int()`` raises, which previously made every legal multi-drone action
+        look like a hallucination.
+        """
+        if hasattr(self.action_space, "nvec"):
+            return np.asarray(action, dtype=np.int64).reshape(self.action_space.nvec.shape)
+        return int(action)
+
     def validate(self, obs, action, reward):
         errors = []
 
@@ -46,8 +58,7 @@ class IntegrityValidator:
 
         # Action hallucination check
         try:
-            action = int(action)  # cast for discrete space
-            if not self.action_space.contains(action):
+            if not self.action_space.contains(self._as_action(action)):
                 errors.append({"type": "hallucination", "field": "action", "msg": "invalid action"})
         except Exception:
             errors.append({"type": "hallucination", "field": "action", "msg": "invalid action"})
@@ -74,6 +85,12 @@ class PolicyIntegrityValidator:
         self.action_space = action_space
         self.strict = strict  # strict=True -> tighter tolerance for prob sums
 
+    def _as_action(self, action):
+        """Match the action to the shape its space declares. See IntegrityValidator."""
+        if hasattr(self.action_space, "nvec"):
+            return np.asarray(action, dtype=np.int64).reshape(self.action_space.nvec.shape)
+        return int(action)
+
     def validate(self, action_probs, value, action):
         errors = []
 
@@ -81,9 +98,12 @@ class PolicyIntegrityValidator:
         if (action_probs < 0).any():
             errors.append({"type": "drift", "field": "probs", "msg": "negative action probability"})
 
-        # Check that probs sum to ~1
+        # Check that probs sum to ~1. With one row per drone, every row is its
+        # own distribution and each must sum to 1 independently; summing the
+        # whole tensor would total the number of drones and hide a broken row.
         sum_tol = 1e-2 if not self.strict else 1e-5
-        if not torch.isclose(action_probs.sum(), torch.tensor(1.0), atol=sum_tol):
+        totals = action_probs.sum(dim=-1) if action_probs.dim() > 1 else action_probs.sum()
+        if not torch.isclose(totals, torch.ones_like(totals), atol=sum_tol).all():
             errors.append({"type": "drift", "field": "probs", "msg": "action probabilities do not sum to 1"})
 
         # Value sanity
@@ -92,8 +112,7 @@ class PolicyIntegrityValidator:
 
         # Action hallucination check
         try:
-            action = int(action)
-            if not self.action_space.contains(action):
+            if not self.action_space.contains(self._as_action(action)):
                 errors.append({"type": "hallucination", "field": "action", "msg": "invalid action index"})
         except Exception:
             errors.append({"type": "hallucination", "field": "action", "msg": "invalid action index"})

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,8 @@ Why separate this?
 
 import argparse
 import os
+
+import numpy as np
 from pathlib import Path
 from typing import Any, Dict
 
@@ -132,7 +134,8 @@ def run_inference(agent, env, rollout_len=5):
         stats.record_env(info)
         total_reward += reward
 
-        print(f"Step {t+1}: action={env.action_map[action]}, reward={reward:.2f}")
+        names = ", ".join(env.action_map[int(a)] for a in np.atleast_1d(action))
+        print(f"Step {t+1}: actions=[{names}], reward={reward:.2f}")
 
         if terminated or truncated:
             break

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@ replaced the agent with a dummy that returned a constant, which meant the
 /predict contract could be broken without a single test noticing, and it was.
 """
 
+import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
@@ -18,20 +19,27 @@ def client():
         yield c
 
 
-def test_predict_returns_a_legal_action(client):
-    """A real observation produces an action inside the action space."""
+def test_predict_returns_a_legal_action_per_drone(client):
+    """A real observation produces one legal action for every drone."""
     obs, _ = env.reset()
     response = client.post("/predict", json={"state": obs.tolist()})
 
     assert response.status_code == 200
     body = response.json()
-    assert body["action"] in range(env.action_space.n)
-    assert body["action_name"] == env.action_map[body["action"]]
+    assert len(body["actions"]) == env.num_drones
+    assert env.action_space.contains(np.asarray(body["actions"], dtype=np.int64))
+    assert body["action_names"] == [env.action_map[a] for a in body["actions"]]
 
 
-def test_predict_rejects_a_wrong_length_state(client):
-    """Too few values is a client error, not a policy failure."""
-    response = client.post("/predict", json={"state": [0, 0, 1]})
+def test_predict_rejects_a_wrong_row_count(client):
+    """One row per drone; too few is a client error, not a policy failure."""
+    response = client.post("/predict", json={"state": [[0] * 9]})
+    assert response.status_code == 422
+
+
+def test_predict_rejects_a_wrong_row_width(client):
+    """Right number of drones, wrong number of features."""
+    response = client.post("/predict", json={"state": [[0, 0, 1]] * env.num_drones})
     assert response.status_code == 422
 
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -26,7 +26,8 @@ def test_env_integrity_validator_clean_run():
     """
     env = DroneEnv()
     _, _ = env.reset()
-    _, _, _, _, info = env.step(0)  # action 0 = hover
+    # One action per drone; hovering is always legal.
+    _, _, _, _, info = env.step([0] * env.num_drones)
     assert "integrity_errors" not in info
     env.close()
 

--- a/tests/test_multi_drone.py
+++ b/tests/test_multi_drone.py
@@ -1,0 +1,122 @@
+"""
+Multi-drone and conflict tests.
+
+num_drones sat in configs/env.yaml being read and never used; the environment
+tracked a single position vector. These cover the fleet contract and the three
+conflicts a path-finding step has to refuse.
+
+Conflicts are resolved by refusing both movers rather than by priority. A
+priority rule would quietly teach the policy that some drones always win, which
+is a coordination bug disguised as a tie-break.
+"""
+
+import numpy as np
+import pytest
+
+from env.drone_env import DroneEnv
+
+
+@pytest.fixture
+def pair(tmp_path):
+    """Two drones on a clear grid, positioned by hand per test."""
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text("grid_size: 8\nnum_drones: 2\nobstacle_density: 0.0\nmax_steps: 50\n")
+    e = DroneEnv(str(cfg))
+    e.reset(seed=0)
+    e.obstacles[:] = False
+    try:
+        yield e
+    finally:
+        e.close()
+
+
+def test_fleet_size_comes_from_config():
+    e = DroneEnv()
+    assert e.num_drones == 10
+    obs, _ = e.reset(seed=0)
+    assert obs.shape == (10, 9)
+    assert list(e.action_space.nvec) == [5] * 10
+    e.close()
+
+
+def test_every_drone_starts_and_aims_somewhere_distinct():
+    e = DroneEnv()
+    e.reset(seed=3)
+    starts = {tuple(p) for p in e.positions.tolist()}
+    goals = {tuple(g) for g in e.goals.tolist()}
+    assert len(starts) == e.num_drones
+    assert len(goals) == e.num_drones
+    e.close()
+
+
+def test_wrong_number_of_actions_is_refused(pair):
+    with pytest.raises(ValueError):
+        pair.step([1])
+
+
+def test_vertex_conflict_refuses_both(pair):
+    """Two drones claiming one cell: neither is allowed to take it."""
+    pair.positions = np.array([[2.0, 2.0], [4.0, 2.0]], dtype=np.float32)
+    pair.goals = np.array([[0.0, 0.0], [7.0, 7.0]], dtype=np.float32)
+
+    _, reward, _, _, info = pair.step([4, 3])  # right, left -> both want (3, 2)
+
+    assert np.array_equal(pair.positions, np.array([[2.0, 2.0], [4.0, 2.0]], dtype=np.float32))
+    assert info["collisions"] == 2
+    assert reward == -4.0
+
+
+def test_swap_conflict_refuses_both(pair):
+    """Adjacent drones cannot trade places; they would pass through each other."""
+    pair.positions = np.array([[2.0, 2.0], [3.0, 2.0]], dtype=np.float32)
+    pair.goals = np.array([[0.0, 0.0], [7.0, 7.0]], dtype=np.float32)
+
+    _, _, _, _, info = pair.step([4, 3])  # right, left
+
+    assert np.array_equal(pair.positions, np.array([[2.0, 2.0], [3.0, 2.0]], dtype=np.float32))
+    assert info["collisions"] == 2
+
+
+def test_moving_into_a_stationary_drone_is_refused(pair):
+    """Only the mover is penalised; the drone that held its ground is not."""
+    pair.positions = np.array([[2.0, 2.0], [3.0, 2.0]], dtype=np.float32)
+    pair.goals = np.array([[0.0, 0.0], [7.0, 7.0]], dtype=np.float32)
+
+    _, _, _, _, info = pair.step([4, 0])  # right into a hovering neighbour
+
+    assert np.array_equal(pair.positions, np.array([[2.0, 2.0], [3.0, 2.0]], dtype=np.float32))
+    assert info["collisions"] == 1
+
+
+def test_drones_see_each_other(pair):
+    """A neighbour reads as blocked, the same as a wall or an obstacle."""
+    pair.positions = np.array([[2.0, 2.0], [2.0, 3.0]], dtype=np.float32)
+    obs = pair._get_obs()
+    assert obs[0][5] == 1.0   # drone 0 looking up at drone 1
+    assert obs[1][6] == 1.0   # drone 1 looking down at drone 0
+
+
+def test_independent_moves_both_succeed(pair):
+    pair.positions = np.array([[1.0, 1.0], [5.0, 5.0]], dtype=np.float32)
+    pair.goals = np.array([[0.0, 0.0], [7.0, 7.0]], dtype=np.float32)
+
+    _, reward, _, _, info = pair.step([4, 4])  # both right, far apart
+
+    assert np.array_equal(pair.positions, np.array([[2.0, 1.0], [6.0, 5.0]], dtype=np.float32))
+    assert "collisions" not in info
+    assert reward == -2.0  # one per drone
+
+
+def test_episode_ends_only_when_every_drone_is_home(pair):
+    pair.positions = np.array([[1.0, 1.0], [5.0, 5.0]], dtype=np.float32)
+    pair.goals = np.array([[2.0, 1.0], [7.0, 7.0]], dtype=np.float32)
+
+    _, _, terminated, _, info = pair.step([4, 0])  # only drone 0 arrives
+    assert info["at_goal"] == 1
+    assert not terminated
+
+    pair.positions = np.array([[2.0, 1.0], [7.0, 7.0]], dtype=np.float32)
+    _, reward, terminated, _, info = pair.step([0, 0])
+    assert info["at_goal"] == 2
+    assert terminated
+    assert reward == 20.0  # +10 each

--- a/tests/test_obstacles.py
+++ b/tests/test_obstacles.py
@@ -2,9 +2,9 @@
 Obstacle tests.
 
 obstacle_density sat in configs/env.yaml being read into an attribute and never
-used. These cover the behaviour that field now buys: obstacles are generated at
-roughly the configured rate, they refuse movement, they cost more than an
-ordinary step, and the drone can sense them before walking into them.
+used. These cover what that field now buys: obstacles appear at roughly the
+configured rate, they refuse movement, they cost more than an ordinary step,
+and a drone can sense one before walking into it.
 """
 
 import numpy as np
@@ -22,22 +22,36 @@ def env():
         e.close()
 
 
-def test_observation_is_nine_dimensional_and_in_space(env):
+@pytest.fixture
+def solo(tmp_path):
+    """A one-drone, obstacle-free grid, for testing a single mechanic in isolation."""
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text("grid_size: 8\nnum_drones: 1\nobstacle_density: 0.0\nmax_steps: 50\n")
+    e = DroneEnv(str(cfg))
+    e.reset(seed=0)
+    try:
+        yield e
+    finally:
+        e.close()
+
+
+def test_observation_is_one_row_of_nine_per_drone(env):
     obs, _ = env.reset(seed=0)
-    assert obs.shape == (9,)
+    assert obs.shape == (env.num_drones, 9)
     assert env.observation_space.contains(obs)
 
 
-def test_start_and_goal_are_never_blocked(env):
-    """A blocked start is meaningless and a blocked goal is unwinnable."""
-    for seed in range(25):
+def test_no_drone_starts_or_aims_at_an_obstacle(env):
+    """Starts and goals are drawn from free cells, so neither can be blocked."""
+    for seed in range(20):
         env.reset(seed=seed)
-        assert not env.obstacles[0, 0]
-        assert not env.obstacles[env.grid_size - 1, env.grid_size - 1]
+        for pos in env.positions:
+            assert not env.obstacles[int(pos[0]), int(pos[1])]
+        for goal in env.goals:
+            assert not env.obstacles[int(goal[0]), int(goal[1])]
 
 
 def test_obstacle_rate_tracks_the_configured_density(env):
-    """Averaged over seeds, the draw should sit near obstacle_density."""
     rates = []
     for seed in range(30):
         env.reset(seed=seed)
@@ -53,54 +67,46 @@ def test_same_seed_gives_the_same_obstacles(env):
     assert np.array_equal(first, env.obstacles)
 
 
-def test_moving_into_an_obstacle_is_refused_and_costs_extra(env):
-    """Position is unchanged, the step is flagged, and it costs more than a plain move."""
-    env.reset(seed=0)
-    # Plant an obstacle directly above the drone, then try to move up.
-    env.obstacles[:] = False
-    env.obstacles[0, 1] = True
-    before = env.position.copy()
+def test_moving_into_an_obstacle_is_refused_and_costs_extra(solo):
+    """Position unchanged, the step flagged, and dearer than a plain move."""
+    solo.positions = np.array([[2.0, 2.0]], dtype=np.float32)
+    solo.goals = np.array([[7.0, 7.0]], dtype=np.float32)
+    solo.obstacles[:] = False
+    solo.obstacles[2, 3] = True  # directly above
 
-    obs, reward, terminated, truncated, info = env.step(1)  # up
+    obs, reward, terminated, truncated, info = solo.step([1])  # up
 
-    assert np.array_equal(env.position, before)
-    assert info.get("collision") is True
+    assert np.array_equal(solo.positions, np.array([[2.0, 2.0]], dtype=np.float32))
+    assert info.get("collisions") == 1
     assert reward == -2.0
     assert not terminated
 
 
-def test_a_clear_move_is_not_flagged_and_costs_one(env):
-    env.reset(seed=0)
-    env.obstacles[:] = False
-    before = env.position.copy()
+def test_a_clear_move_is_not_flagged_and_costs_one(solo):
+    solo.positions = np.array([[2.0, 2.0]], dtype=np.float32)
+    solo.goals = np.array([[7.0, 7.0]], dtype=np.float32)
+    solo.obstacles[:] = False
 
-    obs, reward, terminated, truncated, info = env.step(1)  # up
+    obs, reward, terminated, truncated, info = solo.step([1])  # up
 
-    assert not np.array_equal(env.position, before)
-    assert "collision" not in info
+    assert np.array_equal(solo.positions, np.array([[2.0, 3.0]], dtype=np.float32))
+    assert "collisions" not in info
     assert reward == -1.0
 
 
-def test_sensor_flags_report_adjacent_obstacles(env):
-    """The four trailing observation values are up, down, left, right."""
-    env.reset(seed=0)
-    env.obstacles[:] = False
-    env.obstacles[0, 1] = True  # directly above the start at (0, 0)
+def test_sensor_flags_report_obstacles_and_edges(solo):
+    """The four trailing values per row are up, down, left, right."""
+    solo.positions = np.array([[0.0, 0.0]], dtype=np.float32)
+    solo.obstacles[:] = False
+    solo.obstacles[0, 1] = True  # directly above the corner
 
-    obs = env._get_obs()
-    up, down, left, right = obs[5], obs[6], obs[7], obs[8]
+    up, down, left, right = solo._get_obs()[0][5:9]
 
-    assert up == 1.0        # the obstacle
-    assert down == 1.0      # the grid edge reads as impassable too
-    assert left == 1.0      # edge
-    assert right == 0.0     # clear
+    assert up == 1.0      # the obstacle
+    assert down == 1.0    # the grid edge reads as impassable too
+    assert left == 1.0    # edge
+    assert right == 0.0   # clear
 
 
-def test_zero_density_produces_no_obstacles(tmp_path):
-    """A density of zero must leave the grid completely clear."""
-    config = tmp_path / "env.yaml"
-    config.write_text("grid_size: 10\nnum_drones: 1\nobstacle_density: 0.0\nmax_steps: 50\n")
-    e = DroneEnv(str(config))
-    e.reset(seed=3)
-    assert not e.obstacles.any()
-    e.close()
+def test_zero_density_produces_no_obstacles(solo):
+    assert not solo.obstacles.any()


### PR DESCRIPTION
## Problem

- `num_drones: 10` has been in `configs/env.yaml` since the first commit, read into an attribute and never used. The environment tracked a single position vector, so **both halves of the repository name described nothing**: no fleet, and no path finding between agents.

## Fix

- **The fleet shares one grid.** Observation is `(num_drones, 9)`, a row per drone; action is `MultiDiscrete`, one move each. A single drone is the degenerate case of the same shape.
- **Policy weights are shared across drones** rather than duplicated, so the network does not grow with the fleet and a lesson learned by one drone is available to all. A joint action space was the alternative and is not viable: five moves across ten drones is `5^10`.
- **Path finding is the step function.** Three conflicts are detected and refused: two drones claiming one cell, two swapping cells, and one moving into a drone that is holding still.
- **Refusal rather than priority**, deliberately. A priority rule would quietly teach the policy that some drones always win. And only the mover is faulted when its neighbour stands its ground, since penalising a drone for holding position would make hovering look risky.
- **Drones sense each other**: a neighbour reads as blocked exactly like a wall or an obstacle, which is what makes yielding learnable at all.

Two bugs surfaced while building this, both caught by running rather than reading:

1. `IntegrityValidator` could not handle a `MultiDiscrete` space. `int(action)` raises on a vector, so **every legal fleet action was being flagged as a hallucination**. It now shapes the action to whatever its space declares, and still catches action `999`.
2. The first conflict pass penalised a stationary drone for its neighbour's bad move.

## Tests

Verified by running, not by reading.

- [x] Unit: fleet size comes from config, observation is `(10, 9)`, action space is `MultiDiscrete([5] * 10)`
- [x] Unit: every drone gets a distinct start and a distinct goal
- [x] Edge cases: a wrong number of actions raises rather than silently truncating
- [x] Unit: **vertex conflict** refuses both movers, reward `-4.0`, two collisions
- [x] Unit: **swap conflict** refuses both, so drones cannot pass through each other
- [x] Unit: **moving into a stationary drone** refuses only the mover, one collision
- [x] Unit: drones read each other as blocked in the sensor flags
- [x] Unit: independent moves both succeed with no collisions
- [x] Unit: the episode ends only when every drone is home, `+10.0` each
- [x] Integration: full suite **23 to 33 tests**, 87 percent coverage, green in the Docker image
- [x] Happy path: training 10 drones exits 0 with zero drift and zero hallucination; per-step reward of `-12.00` against `-10.00` shows conflicts firing in a live rollout
- [x] Automated UI sanity: live API returns ten actions with names; rejects a wrong row count and a wrong row width with distinct 422 messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
