### PR TITLE
Add the Safety Controller, the one component allowed to veto

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 <img alt="python 3.10" src="https://img.shields.io/badge/python-3.10-dfe3e0?style=flat-square&labelColor=0d1410">
 <img alt="PPO in PyTorch 2.2.2" src="https://img.shields.io/badge/PPO-PyTorch_2.2.2-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="env gymnasium" src="https://img.shields.io/badge/env-gymnasium-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="tests 33 passing" src="https://img.shields.io/badge/tests-33_passing-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="coverage 87 percent" src="https://img.shields.io/badge/coverage-87%25-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="tests 42 passing" src="https://img.shields.io/badge/tests-42_passing-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="coverage 88 percent" src="https://img.shields.io/badge/coverage-88%25-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="license Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-8f9491?style=flat-square&labelColor=0d1410">
 
 <br/><br/>
@@ -87,7 +87,26 @@ Two validators in [`src/integrity_validators.py`](src/integrity_validators.py), 
   - Hallucination errors: 0 (0.00% of steps)
 ```
 
-The validators report and continue; they do not halt a run. That is a deliberate choice for a training loop and the wrong one for a flight controller, which is what the Safety Controller in the roadmap is for.
+The validators report and continue; they do not halt a run. That is the right call for a training loop and the wrong one for anything that flies, which is why the [Safety Controller](#the-safety-controller) exists as a separate component. Reporting and refusing are different jobs and are kept in different objects.
+
+---
+
+## The Safety Controller
+
+The one component here allowed to **veto**. Everything else in the integrity layer describes what happened; this changes what happens. It sits between the policy's proposal and the environment's movement resolution, so a move it refuses never reaches conflict resolution at all.
+
+Two rules, both geometric, because a rule that cannot be checked cheaply on every tick is a rule that gets skipped on a busy one.
+
+| rule | config | refuses |
+|---|---|---|
+| Geofence | `geofence_margin` | Any move into the margin around the grid border. Drones are never spawned inside it either |
+| Separation | `min_separation` | Any move ending closer than this Chebyshev distance to another drone |
+
+Both default to permissive. A controller that changed behaviour the moment it was installed would make its effect impossible to separate from the policy's.
+
+**Separation defaults to `0`, not `1`, for a sharper reason.** Two drones in one cell is distance 0, and that case already belongs to the environment's vertex-conflict rule, which refuses *both* movers. A separation rule of `1` would race that rule and settle it first, letting whichever drone happened to be checked first proceed. That is a priority tie-break wearing a safety rule's clothes, and it teaches the policy that some drones always win. The same reasoning makes separation vetoes symmetric: both movers are refused, never just the one the loop reached first.
+
+A drone holding position is never vetoed, including one already inside a forbidden region. Moving it because its current cell became illegal would be worse than leaving it put, and the controller must never manufacture a move it was not asked for.
 
 ---
 
@@ -251,6 +270,9 @@ grid_size: 20
 num_drones: 10          # fleet size; each gets its own start and goal
 obstacle_density: 0.1   # obstacle rate per cell, start and goal always clear
 max_steps: 200
+safety:
+  geofence_margin: 0    # border cells that are off limits; 0 uses the whole grid
+  min_separation: 0     # minimum Chebyshev spacing; 0 leaves it to conflict resolution
 ```
 
 `DroneEnv` resolves a relative config path against the repository root, so it works the same from the repo root, from `src/`, and inside the container. If PyYAML is missing it falls back to a minimal line parser rather than failing.
@@ -286,7 +308,8 @@ Worth reading before the deployment sections. The repository name is older than 
 | Multi-agent, more than one drone | **Implemented**. `num_drones` sets the fleet; shared policy weights across drones |
 | MAPF, multi-agent path finding | **Implemented**. Vertex, swap and stationary conflicts detected and refused each step |
 | Obstacles | **Implemented**. Drawn from `obstacle_density`, refuse movement, and are locally sensed |
-| Ingestion, Preprocess and Prediction agents; Safety Controller; Supervisor | **Design only**, described in [`architecture/summary.md`](architecture/summary.md), no code in `src/` |
+| Safety Controller | **Implemented**. Geofence and separation, the only component permitted to veto |
+| Ingestion, Preprocess and Prediction agents; Supervisor | **Design only**, described in [`architecture/summary.md`](architecture/summary.md), no code in `src/` |
 
 The name now describes the code: multiple drones share one grid, see each other, and have their conflicting moves refused. What remains is the Safety Controller, the first component that would be allowed to veto rather than only report.
 
@@ -340,10 +363,10 @@ Full written spec in [`architecture/low_level_design.txt`](architecture/low_leve
 
 Roughly in dependency order:
 
-1. Safety Controller, the first component allowed to veto rather than only report.
-2. A learned conflict policy: today conflicts are refused, which is correct but blunt. Yielding by priority or by remaining distance would be a real coordination signal.
+1. A learned conflict policy. Today conflicts and vetoes are refusals, which is correct but blunt: the drone simply stops. Yielding, by remaining distance or by who is closer to their goal, would be a real coordination signal rather than a stall.
+2. Altitude and return-to-home, the two rules from the low level design the grid cannot express while it is flat.
 
-Done: multiple drones share the grid with vertex, swap and stationary conflicts refused, obstacles are generated and sensed, the `/predict` contract now takes the 5-number observation vector and is covered by tests that do not stub the agent, and `configs/train.yaml` is loaded and applied rather than silently discarded.
+Done: the Safety Controller vetoes on geofence and separation, multiple drones share the grid with vertex, swap and stationary conflicts refused, obstacles are generated and sensed, the `/predict` contract now takes the 5-number observation vector and is covered by tests that do not stub the agent, and `configs/train.yaml` is loaded and applied rather than silently discarded.
 
 ---
 
@@ -433,9 +456,10 @@ pytest --cov=src --cov-report=term-missing
 | `tests/test_main_config.py` | `--config` is parsed, applied to `PPOAgent`, and unknown flags exit non-zero |
 | `tests/test_obstacles.py` | Density, determinism, refused moves, the collision penalty, and the sensor flags |
 | `tests/test_multi_drone.py` | Fleet contract, distinct starts and goals, and the three conflict kinds |
+| `tests/test_safety_controller.py` | Geofence and separation vetoes, veto symmetry, and that permissive defaults change nothing |
 | `tests/test_load.py` | Repeated stepping under pressure |
 
-Current state: 33 passing, 87 percent line coverage.
+Current state: 42 passing, 88 percent line coverage.
 
 ---
 

--- a/configs/env.yaml
+++ b/configs/env.yaml
@@ -2,3 +2,12 @@ grid_size: 20
 num_drones: 10
 obstacle_density: 0.1
 max_steps: 200
+
+# Safety Controller. Permissive by default so its effect is separable from the
+# policy's. Margin 0 leaves the whole grid usable. Separation 0 is off: two
+# drones in one cell is already the environment's vertex-conflict rule, which
+# refuses both, and a separation rule of 1 would race it and settle it by loop
+# order. Raise either value to see the controller refuse moves.
+safety:
+  geofence_margin: 0
+  min_separation: 0

--- a/src/env/drone_env.py
+++ b/src/env/drone_env.py
@@ -15,6 +15,7 @@ except Exception:  # pragma: no cover
     yaml = None
 
 from integrity_validators import IntegrityValidator
+from safety_controller import SafetyController
 
 # Observation values per drone, before the four sensor flags.
 _BASE_FEATURES = 5
@@ -76,6 +77,9 @@ class DroneEnv(gym.Env):
         self.action_map = {0: "hover", 1: "up", 2: "down", 3: "left", 4: "right"}
 
         self.validator = IntegrityValidator(self.action_space, self.observation_space)
+        # The validators report; this one refuses. It is the only component here
+        # permitted to change what happens rather than just describe it.
+        self.safety = SafetyController(self.grid_size, self.config.get("safety"))
 
         self.positions = np.zeros((self.num_drones, 2), dtype=np.float32)
         self.goals = np.zeros((self.num_drones, 2), dtype=np.float32)
@@ -124,6 +128,8 @@ class DroneEnv(gym.Env):
         rewarded for crowding a single square.
         """
         free = self._free_cells()
+        # Never spawn a drone somewhere the geofence would immediately trap it.
+        free = np.array([c for c in free if self.safety.in_geofence(int(c[0]), int(c[1]))])
         needed = 2 * self.num_drones
         if len(free) < needed:
             raise ValueError(
@@ -224,6 +230,12 @@ class DroneEnv(gym.Env):
             else:
                 intended.append((int(tx), int(ty)))
 
+        # The Safety Controller arbitrates before drones are compared with each
+        # other, so a move it refuses never reaches conflict resolution at all.
+        intended, veto_reasons = self.safety.review(current, intended)
+        for idx in veto_reasons:
+            collided[idx] = True
+
         # Pass 2: drone against drone, repeated until nothing else gives way.
         for _ in range(self.num_drones + 1):
             changed = False
@@ -267,6 +279,9 @@ class DroneEnv(gym.Env):
         info: Dict[str, Any] = {"at_goal": int(at_goal.sum())}
         if any(collided):
             info["collisions"] = int(sum(collided))
+        if veto_reasons:
+            info["safety_vetoes"] = len(veto_reasons)
+            info["veto_reasons"] = sorted(set(veto_reasons.values()))
 
         errors = self.validator.validate(obs, actions, reward)
         if errors:

--- a/src/safety_controller.py
+++ b/src/safety_controller.py
@@ -1,0 +1,111 @@
+"""
+Safety Controller
+-----------------
+The first component in this repository allowed to *veto*.
+
+Everything else in the integrity layer reports and steps aside: a validator
+counts a bad value and the run continues, which is the right call for a
+training loop and the wrong one for anything that flies. The Safety Controller
+is the other half of that idea. It sits between the policy's proposal and the
+environment's movement resolution, and a move it refuses does not happen.
+
+Rules are deliberately few and geometric, because a rule that cannot be checked
+cheaply on every tick is a rule that will be skipped on a busy one.
+"""
+
+from typing import Any, Dict, List, Tuple
+
+
+class SafetyController:
+    """Final arbiter over proposed moves.
+
+    Parameters
+    ----------
+    grid_size:
+        Width of the square grid, used by the geofence.
+    config:
+        Optional mapping with ``geofence_margin`` and ``min_separation``.
+
+    The defaults are permissive on purpose: ``geofence_margin`` of 0 leaves the
+    whole grid usable and ``min_separation`` of 0 disables spacing entirely. A
+    controller that changed behaviour the moment it was installed would make its
+    effect impossible to separate from the policy's.
+
+    Separation defaults to 0 rather than 1 for a sharper reason. Two drones in
+    the same cell is distance 0, and that case already belongs to the
+    environment's vertex-conflict rule, which refuses both movers. A separation
+    rule of 1 would race that rule and settle it first, letting whichever drone
+    was checked first proceed. That is a priority tie-break wearing a safety
+    rule's clothes, and it teaches the policy that some drones always win.
+    """
+
+    def __init__(self, grid_size: int, config: Dict[str, Any] | None = None):
+        config = config or {}
+        self.grid_size = int(grid_size)
+        self.geofence_margin = int(config.get("geofence_margin", 0))
+        self.min_separation = int(config.get("min_separation", 0))
+
+    # ------------------------------------------------------------------
+    # Rules
+    # ------------------------------------------------------------------
+    def in_geofence(self, x: int, y: int) -> bool:
+        """True when the cell is inside the permitted region."""
+        m = self.geofence_margin
+        return m <= x < self.grid_size - m and m <= y < self.grid_size - m
+
+    @staticmethod
+    def _chebyshev(a: Tuple[int, int], b: Tuple[int, int]) -> int:
+        """Chebyshev distance: diagonal neighbours count as one apart."""
+        return max(abs(a[0] - b[0]), abs(a[1] - b[1]))
+
+    # ------------------------------------------------------------------
+    # Arbitration
+    # ------------------------------------------------------------------
+    def review(self, current: List[Tuple[int, int]], proposed: List[Tuple[int, int]]):
+        """Approve or refuse each proposed cell.
+
+        Returns the approved cells and one reason per vetoed drone. A refused
+        drone holds its current cell, which is always treated as safe: sending
+        a drone somewhere else because where it already is has become illegal
+        would be a worse outcome than leaving it put.
+        """
+        approved = list(proposed)
+        reasons: Dict[int, str] = {}
+
+        for i, cell in enumerate(proposed):
+            if cell == current[i]:
+                continue  # holding position is never vetoed
+            if not self.in_geofence(*cell):
+                approved[i] = current[i]
+                reasons[i] = "geofence"
+
+        # Separation is checked after the geofence, and against the cells that
+        # survived it, so one veto cannot cascade into a phantom breach.
+        if self.min_separation > 0:
+            for _ in range(len(proposed) + 1):
+                changed = False
+                for i in range(len(approved)):
+                    if approved[i] == current[i]:
+                        continue
+                    for j in range(len(approved)):
+                        if i == j:
+                            continue
+                        if self._chebyshev(approved[i], approved[j]) >= self.min_separation:
+                            continue
+                        # Refuse both movers, never just the one examined first.
+                        # Vetoing only drone i would hand drone j the cell purely
+                        # because of loop order, which is a priority rule by
+                        # accident and the thing this controller must not become.
+                        approved[i] = current[i]
+                        reasons[i] = "separation"
+                        if approved[j] != current[j]:
+                            approved[j] = current[j]
+                            reasons[j] = "separation"
+                        changed = True
+                        break
+                    if changed:
+                        break
+                if not changed:
+                    break
+
+        return approved, reasons

--- a/tests/test_safety_controller.py
+++ b/tests/test_safety_controller.py
@@ -1,0 +1,130 @@
+"""
+Safety Controller tests.
+
+Everything else in the integrity layer reports and steps aside. This is the one
+component allowed to refuse, so these cover both that it refuses when it should
+and, just as importantly, that it stays out of the way when it should not.
+"""
+
+import numpy as np
+import pytest
+
+from env.drone_env import DroneEnv
+from safety_controller import SafetyController
+
+
+def _env(tmp_path, drones=2, margin=0, separation=0, grid=10):
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text(
+        f"grid_size: {grid}\nnum_drones: {drones}\nobstacle_density: 0.0\n"
+        f"max_steps: 50\nsafety:\n  geofence_margin: {margin}\n  min_separation: {separation}\n"
+    )
+    e = DroneEnv(str(cfg))
+    e.reset(seed=0)
+    e.obstacles[:] = False
+    return e
+
+
+def test_defaults_are_permissive():
+    """Installing the controller must not change behaviour on its own."""
+    c = SafetyController(grid_size=20)
+    assert c.geofence_margin == 0
+    assert c.min_separation == 0
+
+
+def test_shipped_config_is_wired_in():
+    e = DroneEnv()
+    assert isinstance(e.safety, SafetyController)
+    assert e.safety.geofence_margin == 0
+    assert e.safety.min_separation == 0
+    e.close()
+
+
+def test_separation_defaults_to_zero_so_it_cannot_race_the_conflict_rule():
+    """
+    A separation of 1 would fire on two drones entering one cell, which is
+    already the vertex-conflict rule's job. Whichever ran first would decide,
+    handing one drone the cell by loop order rather than by any rule.
+    """
+    c = SafetyController(grid_size=10)
+    approved, reasons = c.review([(2, 2), (4, 2)], [(3, 2), (3, 2)])
+    assert reasons == {}          # the controller stays out of it
+    assert approved == [(3, 2), (3, 2)]  # left for conflict resolution to refuse
+
+
+def test_geofence_refuses_a_move_into_the_margin(tmp_path):
+    e = _env(tmp_path, drones=1, margin=2)
+    e.positions = np.array([[2.0, 5.0]], dtype=np.float32)
+    e.goals = np.array([[7.0, 7.0]], dtype=np.float32)
+
+    _, _, _, _, info = e.step([3])  # left, into the 2-cell margin
+
+    assert np.array_equal(e.positions, np.array([[2.0, 5.0]], dtype=np.float32))
+    assert info["safety_vetoes"] == 1
+    assert info["veto_reasons"] == ["geofence"]
+    e.close()
+
+
+def test_geofence_allows_a_move_that_stays_inside(tmp_path):
+    e = _env(tmp_path, drones=1, margin=2)
+    e.positions = np.array([[5.0, 5.0]], dtype=np.float32)
+    e.goals = np.array([[7.0, 7.0]], dtype=np.float32)
+
+    _, _, _, _, info = e.step([3])  # left, well clear of the margin
+
+    assert np.array_equal(e.positions, np.array([[4.0, 5.0]], dtype=np.float32))
+    assert "safety_vetoes" not in info
+    e.close()
+
+
+def test_drones_never_spawn_inside_the_geofence(tmp_path):
+    e = _env(tmp_path, drones=3, margin=3, grid=12)
+    for seed in range(15):
+        e.reset(seed=seed)
+        for pos in e.positions:
+            assert e.safety.in_geofence(int(pos[0]), int(pos[1]))
+        for goal in e.goals:
+            assert e.safety.in_geofence(int(goal[0]), int(goal[1]))
+    e.close()
+
+
+def test_separation_refuses_both_movers(tmp_path):
+    """Symmetry matters: vetoing only the drone checked first is a priority rule."""
+    e = _env(tmp_path, drones=2, separation=2)
+    e.positions = np.array([[2.0, 2.0], [5.0, 2.0]], dtype=np.float32)
+    e.goals = np.array([[0.0, 0.0], [9.0, 9.0]], dtype=np.float32)
+
+    # They close to (3,2) and (4,2), one apart, which breaches a separation of 2.
+    _, _, _, _, info = e.step([4, 3])
+
+    assert np.array_equal(e.positions, np.array([[2.0, 2.0], [5.0, 2.0]], dtype=np.float32))
+    assert info["safety_vetoes"] == 2
+    assert info["veto_reasons"] == ["separation"]
+    e.close()
+
+
+def test_separation_faults_only_the_mover_against_a_stationary_drone(tmp_path):
+    """A drone holding its ground is not at fault for someone else approaching."""
+    e = _env(tmp_path, drones=2, separation=2)
+    e.positions = np.array([[3.0, 2.0], [5.0, 2.0]], dtype=np.float32)
+    e.goals = np.array([[0.0, 0.0], [9.0, 9.0]], dtype=np.float32)
+
+    # The mover would land on (4,2), one cell from a drone that never moved.
+    _, _, _, _, info = e.step([4, 0])
+
+    assert np.array_equal(e.positions, np.array([[3.0, 2.0], [5.0, 2.0]], dtype=np.float32))
+    assert info["safety_vetoes"] == 1
+    e.close()
+
+
+def test_holding_position_is_never_vetoed(tmp_path):
+    """
+    A drone already inside a forbidden region is left where it is. Moving it
+    because its current cell became illegal would be a worse outcome than
+    leaving it put, and the controller must never manufacture a move.
+    """
+    c = SafetyController(grid_size=10, config={"geofence_margin": 3})
+    current = [(0, 0)]  # already outside the fence
+    approved, reasons = c.review(current, [(0, 0)])
+    assert approved == [(0, 0)]
+    assert reasons == {}


### PR DESCRIPTION
## Problem

- The integrity layer could only ever **report**. A validator counts a bad value and the run continues, which is right for a training loop and wrong for anything that flies. Nothing in `src/` was permitted to change what happened.
- The Safety Controller was the last item described in `architecture/summary.md` with no code behind it.

## Fix

- **`src/safety_controller.py`**: sits between the policy's proposal and the environment's movement resolution, so a refused move never reaches conflict resolution at all.
- Two geometric rules: **geofence** (`geofence_margin`) and **separation** (`min_separation`). Geometric on purpose, since a rule that cannot be checked cheaply every tick gets skipped on a busy one.
- Both **permissive by default**. A controller that changed behaviour the moment it was installed would make its effect impossible to separate from the policy's.
- Drones are never spawned inside the geofence, and **a drone holding position is never vetoed**, including one already inside a forbidden region: moving it because its current cell became illegal would be worse than leaving it put.

**The design bug worth reading.** My first version defaulted `min_separation` to `1`, and the existing vertex-conflict test caught it immediately. Two drones entering one cell is distance 0, so a separation of `1` fired *before* the vertex-conflict rule and vetoed whichever drone the loop reached first, letting the other through. That is a priority tie-break wearing a safety rule's clothes, and it is precisely the bias the conflict rule was written to avoid. Fixed two ways: separation defaults to `0` so it cannot race that rule, and separation vetoes are now symmetric, refusing both movers.

## Tests

Verified by running, not by reading.

- [x] Unit: defaults are permissive, and the shipped `configs/env.yaml` is wired through to the controller
- [x] Unit: separation of `0` leaves a two-into-one-cell case entirely to conflict resolution, issuing no veto
- [x] Unit: geofence refuses a move into the margin and reports `veto_reasons == ["geofence"]`; a move that stays inside is untouched
- [x] Edge cases: across 15 seeds, no drone or goal is ever placed inside the geofence
- [x] Unit: a separation breach between two movers refuses **both**, not just the one checked first
- [x] Unit: against a stationary drone, only the mover is faulted
- [x] Edge cases: a drone already inside a forbidden region is left where it is, never relocated
- [x] Integration: full suite **33 to 42 tests**, 88 percent coverage, green in the Docker image
- [x] Happy path: training exits 0 with zero drift and zero hallucination
- [x] Happy path: with `geofence_margin: 3` and `min_separation: 2`, the controller issued **11 vetoes across 12 steps** of both kinds, and every drone finished inside the fence
- [x] Automated UI sanity: live API still returns ten actions with names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
