### PR TITLE
Close out the remaining documentation and packaging debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,40 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.  
-The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)  
+All notable changes to this project are documented here.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
 ## [Unreleased]
-- Placeholder for upcoming features, fixes, and improvements.
+
+### Added
+- Multiple drones sharing one grid, sized by `num_drones`, with shared policy weights.
+- Path finding: vertex, swap and stationary conflicts detected and refused each step.
+- Obstacles drawn from `obstacle_density`, with four local sensor flags per drone.
+- Safety Controller with geofence and separation rules, the only component permitted to veto.
+- Training configuration via `--config`, applied to the agent rather than discarded.
+- `configs/env-prod.yaml` as a loadable production profile.
+
+### Changed
+- `/predict` takes one observation row per drone and returns action indices and names.
+- Environment migrated from the deprecated `gym` package to `gymnasium`.
+- Observation space bounds are per-dimension.
+- Imports normalised to a single package layout, which unbroke the production image.
+
+### Fixed
+- CI on all three workflows: the `gymnasium` import, an `httpx` incompatibility, and the missing editable install in the Docker image.
+- `observation_space` declared one scalar bound across every dimension, so every step reported a spurious drift error.
+- `/predict` accepted no valid input: the schema wanted a mapping, the policy wanted numbers.
+- `tests/conftest.py` swallowed import errors and substituted stubs, masking both bugs above.
+- `training_reward` was declared but never observed, leaving its Grafana panel empty.
 
 ## [0.1.0] - 2025-09-08
+
 ### Added
-- Initial production baseline created
-- Observability, deployment configs, and utilities
+- Initial production baseline, observability, deployment configs and utilities.
 
 ---
 
-[0.1.0]: https://github.com/your-org/multi-agent-rl-mapf-drone-system/releases/tag/v0.1.0
+[Unreleased]: https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/jameswniu/multi-agent-rl-mapf-drone-navigation/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Worth reading before the deployment sections. The repository name is older than 
 | `IntegrityStats` reporting across a run | **Implemented** |
 | FastAPI service, `/metrics` and `/healthz` | **Implemented** |
 | Docker image, Compose, Kubernetes manifests, Prometheus and Grafana config | **Implemented** as configuration |
-| `/predict` end to end | **Implemented**. Takes the 5-number observation vector |
+| `/predict` end to end | **Implemented**. Takes one observation row per drone |
 | Hyperparameters from `configs/train.yaml` | **Implemented**. Loaded and applied to `PPOAgent` |
 | Multi-agent, more than one drone | **Implemented**. `num_drones` sets the fleet; shared policy weights across drones |
 | MAPF, multi-agent path finding | **Implemented**. Vertex, swap and stationary conflicts detected and refused each step |
@@ -366,7 +366,7 @@ Roughly in dependency order:
 1. A learned conflict policy. Today conflicts and vetoes are refusals, which is correct but blunt: the drone simply stops. Yielding, by remaining distance or by who is closer to their goal, would be a real coordination signal rather than a stall.
 2. Altitude and return-to-home, the two rules from the low level design the grid cannot express while it is flat.
 
-Done: the Safety Controller vetoes on geofence and separation, multiple drones share the grid with vertex, swap and stationary conflicts refused, obstacles are generated and sensed, the `/predict` contract now takes the 5-number observation vector and is covered by tests that do not stub the agent, and `configs/train.yaml` is loaded and applied rather than silently discarded.
+Done: the Safety Controller vetoes on geofence and separation, multiple drones share the grid with vertex, swap and stationary conflicts refused, obstacles are generated and sensed, the `/predict` contract now takes one observation row per drone and is covered by tests that do not stub the agent, and `configs/train.yaml` is loaded and applied rather than silently discarded.
 
 ---
 

--- a/configs/env-prod.yaml
+++ b/configs/env-prod.yaml
@@ -1,14 +1,14 @@
-# Production configuration file
-# Training parameters tuned for real use, not just development
+# Production environment profile.
+# Same schema as env.yaml, so it loads the same way:
+#   DroneEnv("configs/env-prod.yaml")
+# Larger and denser than the development grid, with the Safety Controller
+# actually engaged rather than left permissive.
 
-training:
-  episodes: 100000
-  batch_size: 64
-  learning_rate: 0.0001
+grid_size: 40
+num_drones: 25
+obstacle_density: 0.15
+max_steps: 500
 
-monitoring:
-  prometheus: true
-  log_level: INFO
-
-api:
-  port: 8080
+safety:
+  geofence_margin: 2
+  min_separation: 2

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,14 +1,17 @@
-# This Dockerfile is optimized for production (small, fast image)
+# Production image.
+# Deliberately built the same way as docker/Dockerfile. An earlier version
+# copied src/ to the image root, which left the API unservable because the
+# package layout no longer agreed with what the entrypoints import, and CI
+# never caught it because it only ever built the development image.
+# One layout, one set of import paths.
 
-FROM python:3.10-slim as base
+FROM python:3.10-slim
 WORKDIR /app
 
-# Install dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the actual source code
-COPY src/ .
+COPY . .
+RUN pip install --no-cache-dir -e .
 
-# Run the app
-CMD ["python", "main.py"]
+CMD ["python", "-m", "main"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,16 +1,13 @@
-\# Architecture
+# Architecture
 
+- **Agents**: a shared-weight PPO policy driving every drone.
+- **Environment**: `DroneEnv`, a gymnasium grid world with obstacles and local sensing.
+- **Path finding**: vertex, swap and stationary conflicts detected and refused each step.
+- **Integrity**: validators that report drift and hallucination, plus a Safety Controller that vetoes.
+- **API**: FastAPI serving predictions, metrics and health.
+- **Monitoring**: Prometheus and Grafana.
+- **Deployment**: Docker, Compose, Kubernetes.
 
-
-\- Agents: PPO agents for drone navigation.
-
-\- Environment: Custom Gym-like drone environment.
-
-\- API: FastAPI serving predictions + metrics.
-
-\- Monitoring: Prometheus \& Grafana.
-
-\- Deployment: Docker, Compose, Kubernetes.
-
-
-
+The full design, including the parts not implemented, is in
+[`architecture/low_level_design.txt`](../architecture/low_level_design.txt) and
+rendered in the README.

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,7 @@
 addopts = --cov=src --cov-report=term-missing
 testpaths = tests
 python_files = test_*.py
+# setup.cfg also carries a [tool:pytest] block, which pytest ignores entirely
+# when pytest.ini exists. Its pythonpath setting therefore never applied and the
+# suite only worked because of the editable install. Declared here so it does.
+pythonpath = src

--- a/src/agents/ppo_agent.py
+++ b/src/agents/ppo_agent.py
@@ -21,6 +21,7 @@ import numpy as np
 from torch.distributions import Categorical
 
 from integrity_validators import PolicyIntegrityValidator  # schema-based validator
+from utils.metrics import TRAINING_REWARD  # episode reward, for Prometheus
 
 
 # ---------------- Policy Network ----------------
@@ -190,7 +191,11 @@ class PPOAgent:
                 loss.backward()
                 self.optimizer.step()
 
-            print(f"Episode {ep+1}, total reward={sum(rewards):.2f}")
+            episode_reward = sum(rewards)
+            # Declared in utils/metrics.py and, until now, never written to, so
+            # the Grafana training-reward panel had no series behind it.
+            TRAINING_REWARD.observe(episode_reward)
+            print(f"Episode {ep+1}, total reward={episode_reward:.2f}")
 
     def save(self, path):
         """Save model weights to disk."""

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -15,17 +15,17 @@ import time
 
 # Prometheus metrics utilities
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
-from src.utils.metrics import REQUEST_COUNT, REQUEST_LATENCY
+from utils.metrics import REQUEST_COUNT, REQUEST_LATENCY
 
 # Central logging utility
-from src.utils.logger import get_logger
+from utils.logger import get_logger
 
 # Custom error handling
-from src.utils.errors import APIError, error_handler
+from utils.errors import APIError, error_handler
 
 # Domain-specific code: environment and agent
-from src.env.drone_env import DroneEnv
-from src.agents.ppo_agent import PPOAgent
+from env.drone_env import DroneEnv
+from agents.ppo_agent import PPOAgent
 
 
 class StateInput(BaseModel):

--- a/src/request_response_flow.MD
+++ b/src/request_response_flow.MD
@@ -1,124 +1,47 @@
-1\. Client sends a request
+# Request and response flow
 
+## 1. Client sends a request
 
+`POST /predict` with one observation, a row per drone:
 
-Example:
+```json
+{ "state": [[0, 0, 19, 19, 200, 1, 1, 1, 0]] }
+```
 
-POST /predict with JSON body:
+Each row is `[x, y, goal_x, goal_y, steps_remaining, blocked_up, blocked_down,
+blocked_left, blocked_right]`. The number of rows must equal `num_drones` and
+each row must have exactly nine values; either mismatch returns `422` before the
+request reaches the policy.
 
+## 2. Middleware intercepts
 
+`add_metrics` records the start time, then after the endpoint returns it
+increments `api_requests_total` and observes `api_request_latency_seconds`,
+both labelled by method and endpoint, and logs a line such as:
 
-{ "state": { "drone": \[0, 0], "goal": \[5, 5] } }
+```
+2026-07-31 12:34:56 - api.app - INFO - POST /predict completed in 0.032s
+```
 
+## 3. The endpoint runs
 
+The body is validated, then `PPOAgent.predict` returns one greedy action per
+drone. The response carries both the indices and their names:
 
-2\. Middleware intercepts
+```json
+{ "actions": [4], "action_names": ["right"] }
+```
 
+Indices are what `DroneEnv.step()` accepts; names are what a human reads in a
+log. A failure inside the policy is wrapped as an `APIError` and rendered as
+`{"error": "..."}` with status 500.
 
+## 4. Response leaves the API
 
-The add\_metrics middleware runs before the request reaches /predict.
+The middleware finishes timing, the metrics are already updated, and Prometheus
+sees them on its next scrape.
 
+## 5. Monitoring
 
-
-It records the start time.
-
-
-
-After the endpoint finishes, it calculates how long the request took.
-
-
-
-It increments two Prometheus metrics:
-
-
-
-api\_requests\_total{method="POST", endpoint="/predict"}
-
-
-
-api\_request\_latency\_seconds{method="POST", endpoint="/predict"}
-
-
-
-It also writes a log entry like:
-
-
-
-2025-09-08 12:34:56 - src.api.app - INFO - POST /predict completed in 0.032s
-
-
-
-3\. The /predict endpoint runs
-
-
-
-The request body is parsed into a Python dictionary.
-
-
-
-The PPO agent (PPOAgent) calls its predict() method with this state.
-
-
-
-If it succeeds, the action is returned as JSON:
-
-
-
-{ "action": "move\_up" }
-
-
-
-
-
-If something fails (e.g., invalid input), an APIError is raised.
-
-
-
-The error handler converts it into a structured JSON error:
-
-
-
-{ "error": "Prediction failed: invalid state" }
-
-
-
-
-
-Status code 500 is sent back.
-
-
-
-4\. Response leaves API
-
-
-
-The middleware (from step 2) finishes by logging the total time and sending the response back to the client.
-
-
-
-The metrics are already updated, so Prometheus will see them at the next scrape.
-
-
-
-5\. Monitoring systems interact
-
-
-
-Prometheus periodically calls GET /metrics.
-
-
-
-It collects counters/histograms, which include how many requests succeeded, how long they took, etc.
-
-
-
-Kubernetes (or another orchestrator) calls GET /healthz.
-
-
-
-If it gets { "status": "ok" }, it considers the service alive.
-
-
-
-If this fails repeatedly, Kubernetes restarts the container.
-
+Prometheus scrapes `GET /metrics`. The orchestrator polls `GET /healthz` and
+restarts the container if it stops returning `{"status": "ok"}`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,85 +1,25 @@
 """
 PyTest Fixtures
 ---------------
-This file defines reusable fixtures for our tests.
+Reusable fixtures for the test suite.
 
-Why fixtures?
--> In PyTest, fixtures let us create and clean up objects (like environments or agents)
-   automatically. This keeps tests clean and avoids repeating boilerplate.
-
-Scope:
--> Each fixture here uses scope="function", so a fresh object is created
-   for every test function. This prevents state from leaking between tests.
+This file used to wrap its imports in ``try/except Exception`` and substitute
+stub classes when the real ones failed to import. That masked two separate
+production bugs: a broken gymnasium import surfaced as a confusing
+``AttributeError`` on a stub, and a broken /predict contract passed its tests
+because the stub returned a constant. The imports are now plain, so a missing
+dependency fails loudly at collection where it belongs.
 """
 
 import pytest
-import sys
-import types
 
-# ---------------------------------------------------------------------------
-# Optional imports
-# ---------------------------------------------------------------------------
-# The original project depends on the `env` and `agents` packages which are not
-# present in this kata.  Import errors would cause pytest collection to fail
-# before any tests run.  To keep the tests self‑contained we provide minimal
-# stub implementations when the real packages are missing.
-
-try:  # pragma: no cover - only executed when real packages exist
-    from env.drone_env import DroneEnv  # type: ignore
-except Exception:  # pragma: no cover - exercised in the kata environment
-    class DroneEnv:  # minimal stub
-        def __init__(self, *_, **__):
-            # observation_space and action_space attributes are required by
-            # `PPOAgent` during initialisation.  A simple namespace object is
-            # sufficient here.
-            self.observation_space = types.SimpleNamespace(shape=(2,))
-            self.action_space = types.SimpleNamespace(n=2)
-
-        def close(self):  # no-op cleanup hook
-            pass
-
-    # register stub modules so other imports (e.g. `src.api.app`) succeed
-    env_pkg = types.ModuleType("env")
-    env_pkg.__path__ = []  # mark as package
-    env_mod = types.ModuleType("env.drone_env")
-    env_mod.DroneEnv = DroneEnv
-    sys.modules.setdefault("env", env_pkg)
-    sys.modules.setdefault("env.drone_env", env_mod)
-    # also expose as `src.env.drone_env` for the FastAPI app
-    sys.modules.setdefault("src.env", env_pkg)
-    sys.modules.setdefault("src.env.drone_env", env_mod)
-
-try:  # pragma: no cover - only executed when real packages exist
-    from agents.ppo_agent import PPOAgent  # type: ignore
-except Exception:  # pragma: no cover - exercised in the kata environment
-    class PPOAgent:  # minimal stub
-        def __init__(self, env=None):
-            self.env = env
-
-        def load(self, path):  # pragma: no cover - no behaviour
-            pass
-
-        def predict(self, state):  # simple deterministic action
-            return "stub_action"
-
-    agents_pkg = types.ModuleType("agents")
-    agents_pkg.__path__ = []
-    agents_mod = types.ModuleType("agents.ppo_agent")
-    agents_mod.PPOAgent = PPOAgent
-    sys.modules.setdefault("agents", agents_pkg)
-    sys.modules.setdefault("agents.ppo_agent", agents_mod)
+from env.drone_env import DroneEnv
+from agents.ppo_agent import PPOAgent
 
 
 @pytest.fixture(scope="function")
 def env():
-    """
-    Provides a fresh DroneEnv instance for each test.
-
-    How it works:
-    - Creates a new environment.
-    - Yields it to the test function.
-    - After the test completes, ensures env.close() is called.
-    """
+    """A fresh DroneEnv per test, closed afterwards."""
     e = DroneEnv()
     try:
         yield e
@@ -89,13 +29,7 @@ def env():
 
 @pytest.fixture(scope="function")
 def agent():
-    """
-    Provides a PPOAgent tied to its own fresh DroneEnv.
-
-    Why yield instead of return?
-    -> Yield lets us run teardown code after the test finishes.
-       Here, we make sure the environment is closed to free resources.
-    """
+    """A PPOAgent tied to its own fresh DroneEnv."""
     e = DroneEnv()
     a = PPOAgent(e)
     try:
@@ -106,11 +40,5 @@ def agent():
 
 @pytest.fixture(scope="function")
 def model_path(tmp_path):
-    """
-    Provides a temporary file path for saving/loading models.
-
-    Why tmp_path?
-    -> PyTest gives each test its own temporary directory.
-       Using tmp_path ensures models from one test don’t interfere with others.
-    """
+    """A temporary path for saving and loading model weights."""
     return tmp_path / "ppo_test_model.pt"


### PR DESCRIPTION
## Problem

Ten loose ends, several of them mine. The two that were real bugs rather than rot:

- **The production image could not serve the API.** `docker/Dockerfile.prod` copied `src/` to the image root while `app.py` imported through a `src.` prefix, so the two layouts disagreed. Nothing caught it because **CI only ever built the development Dockerfile**.
- **`tests/conftest.py` swallowed import errors and substituted stubs.** That single pattern masked the gymnasium break *and* the broken `/predict` contract earlier in this repo's history.

The rest: `configs/env-prod.yaml` read by nothing, `training_reward` declared but never observed, `pytest.ini` shadowing `setup.cfg`'s `pythonpath`, `request_response_flow.MD` and `docs/ARCHITECTURE.md` documenting contracts that no longer exist (the latter in escaped markdown that rendered as literal backslashes), a `your-org` placeholder in `CHANGELOG.md`, and two stale claims in my own README.

## Fix

- **Imports normalised to one layout.** `app.py` no longer uses a `src.` prefix, and both images are built the same way. This fixes the packaging split at its cause rather than patching one side. It also mattered for the metric: the same prefix split would have given `TRAINING_REWARD` two separate Prometheus registries once it was actually used.
- **`TRAINING_REWARD` is observed once per episode**, so the Grafana panel has a series behind it.
- **conftest stubs deleted.** A missing dependency now fails loudly at collection, where it belongs.
- **`pytest.ini` declares `pythonpath`**, which `setup.cfg` had been declaring into the void: pytest ignores that block entirely when `pytest.ini` exists.
- `configs/env-prod.yaml` is a loadable profile, docs rewritten to the real contract, CHANGELOG records the work.
- **Dependabot security alerts enabled**: CVE warnings without version-bump PRs.

## Tests

Verified by running, not by reading.

- [x] Automated UI sanity: **the prod image now serves the API**. `/healthz` returns ok and `/predict` returns **200** with ten actions; previously unservable
- [x] Unit: `training_reward` goes from **0 samples to 3 after 3 episodes**
- [x] Integration: **42 tests pass with the conftest stubs removed**, which is the proof they were never needed
- [x] Integration: **42 tests pass in an image built with no `pip install -e .` at all**, proving `pythonpath` now does the work the editable install was silently doing
- [x] Unit: `configs/env-prod.yaml` loads, giving grid 40, 25 drones, observation `(25, 9)` inside its space, with the Safety Controller engaged at margin 2 and separation 2
- [x] Unit: security alerts confirmed **enabled** by read-back, with no `dependabot.yml` restored
- [x] Edge cases: zero occurrences remain of the old `/predict` contract, the escaped markdown, the `your-org` placeholder, or the stale five-number claim
- [x] Unit: README, docs and sources scanned clean for em dashes, en dashes and arrow glyphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
