### PR TITLE
Paint the final frame and hold it before looping the replay

### DIFF
--- a/docs/sim.html
+++ b/docs/sim.html
@@ -261,7 +261,9 @@ let ghostRun = null;     // its untrained counterpart
 let drones = [], trails = [], stems = [], ghosts = [];
 let world = () => new THREE.Vector3();
 let cursor = 0, playing = true;
-const SPEED = 3.2;
+let holding = 0;              // seconds spent dwelling on the finished state
+const SPEED = 3.2;            // frames per second
+const HOLD_SECONDS = 2.4;     // how long to sit on the last frame before looping
 
 function disposeGroup(g) {
   g.traverse(o => {
@@ -476,6 +478,8 @@ function drawCurve(sc, activeEpisodes) {
 function selectRun(idx) {
   run = S.runs[idx];
   cursor = 0;
+  holding = 0;
+  holding = 0;
   el('scrub').max = run.frames.length - 1;
   [...el('runs').children].forEach((b, k) => b.setAttribute('aria-pressed', String(k === idx)));
   drawCurve(S, run.episodes);
@@ -526,6 +530,7 @@ el('play').addEventListener('click', () => {
 });
 el('scrub').addEventListener('input', e => {
   playing = false; el('play').textContent = 'Play';
+  holding = 0;
   cursor = Number(e.target.value); paint();
 });
 el('ghost').addEventListener('change', paint);
@@ -546,8 +551,22 @@ renderer.setAnimationLoop(now => {
   const dt = Math.min(0.1, Math.max(0, (now - last) / 1000));
   last = now;
   if (playing) {
-    cursor += dt * SPEED;
-    if (cursor >= run.frames.length - 1) cursor = 0;
+    const lastFrame = run.frames.length - 1;
+    if (cursor >= lastFrame) {
+      // Land on the final frame and stay there for a beat. The previous loop
+      // reset the cursor the moment it reached this point, so the last frame
+      // was never painted at all: playback jumped from the second-to-last step
+      // straight back to the start, and the finished state, every drone home,
+      // was the one thing the replay never actually showed.
+      cursor = lastFrame;
+      holding += dt;
+      if (holding >= HOLD_SECONDS) {
+        holding = 0;
+        cursor = 0;
+      }
+    } else {
+      cursor = Math.min(lastFrame, cursor + dt * SPEED);
+    }
   }
   paint();
   controls.update();


### PR DESCRIPTION
## Problem

The playback loop reset the cursor the instant it reached the last frame:

```js
cursor += dt * SPEED;
if (cursor >= run.frames.length - 1) cursor = 0;
```

So the last frame was never painted. Playback ran to the second-to-last step and jumped straight back to the start, which means the finished state, every drone standing on its goal, was the one thing the replay never showed. The animation skipped the moment it exists for.

## Fix

Clamp the cursor to the last frame, dwell there for 2.4 seconds, then loop.

On the fleet profile that is the beat where the fourth drone finally arrives at step 14 and all four read as home, after the other three have been holding station waiting for it since steps 8, 4 and 1.

The dwell timer resets on scrub and on switching run or scenario, or a run entered at its end would loop away immediately.

## Tests

Testing taxonomy: Automated UI sanity, Manual UI sanity, Edge cases.

- [x] Automated UI sanity: sampled the step readout across a full loop in the browser. Step 14 now appears, reports `4/4` at goal, persists for 2280 ms, and is followed by step 1. Before the change the sequence ran `... 12 13 1 1 ...` with no 14 in it
- [x] Manual UI sanity: final frame renders all four drones green on their goals, timeline at `14 / 14`, refused `0`
- [x] Manual UI sanity: zero console errors on the served page
- [x] Edge cases: dwell timer cleared on scrub and on run or scenario switch, so selecting a checkpoint does not inherit a partially elapsed hold

Quality gates: viewer-only change, no Python touched, so the backend suite is unaffected.