### PR TITLE
Give obstacles height and drones altitude, so terrain becomes a decision

### DIFF
--- a/configs/fly-fleet.yaml
+++ b/configs/fly-fleet.yaml
@@ -1,0 +1,46 @@
+# Four drones, one barrier, and a queue.
+#
+# The single drone profile proves a drone can learn where to climb. This one adds
+# the part that only exists with a fleet: the crossable gaps in the wall are
+# scarce, so four drones heading for the same low span have to take turns.
+#
+# Altitude is what makes that survivable rather than a deadlock. Two drones in
+# one column at different heights are not in conflict, so a drone can pass over
+# one that is waiting instead of both refusing and neither moving. That is the
+# same reasoning as never masking peer occupancy: a rule that forbids approaching
+# another drone removes the manoeuvre that resolves the jam.
+#
+# Sized to the board the fleet already solves without flight. A 10 wide version
+# with fewer crossings was measured first and improves far too slowly to call
+# solved: 55 percent of drones home at 8000 episodes and 65 percent at 20000,
+# every run still hitting the step limit. The drones were climbing, roughly three
+# per run, so the mechanic was not the obstacle; the search was simply too big.
+#
+# This profile is NOT solved, and 8000 episodes is where it is least unsolved:
+# 3 seeds of 5 bring every drone home, 80 percent of drones arrive, and each of
+# the four climbs exactly once. Training further makes it worse, not better,
+# reaching 1 seed of 5 at 20000 and 0 of 5 at 40000.
+#
+# Batching the updates was the obvious suspect, since PPO here updates on a
+# single episode at a time. Gathering 16 before each update was measurably worse
+# at the same episode count, 20 percent of drones home at 8000 and 40 percent at
+# 20000, because a batch of 16 also means a sixteenth of the gradient steps. The
+# knob is still there as batch_episodes; what is not yet known is whether a
+# smaller batch with proportionally more episodes beats either, and that is the
+# next thing to measure rather than something to guess at.
+
+grid_size: 8
+num_drones: 4
+terrain: ridge
+ridges: 1
+low_obstacle_ratio: 0.75
+max_altitude: 1
+altitude_penalty: 0.5
+max_steps: 40
+reward_shaping: true
+shaping_potential: terrain
+fixed_layout: true
+
+safety:
+  geofence_margin: 0
+  min_separation: 0

--- a/configs/fly.yaml
+++ b/configs/fly.yaml
@@ -1,0 +1,40 @@
+# One drone, and a barrier it has to decide how to cross.
+#
+# Scattered obstacles turned out to test nothing. On a random board the trained
+# drone reached its goal at the true optimum having never once climbed, because a
+# clear ground route existed the whole time: the mechanic worked and the task
+# never asked for it.
+#
+# A wall asks. It spans the board between every start and every goal, most of it
+# low enough to fly over and some of it solid, so crossing is not one reflex: the
+# drone climbs where climbing works and walks to a crossing point where it does
+# not. There is no ground route at all, so a drone that never learns to climb
+# never arrives.
+#
+# altitude_penalty keeps the choice honest, because height is free to hold once
+# gained. Without a cost per airborne step the drone would climb on turn one and
+# treat the whole ridge as absent.
+#
+# On raising it: a second wall only poses a new question when dropping between
+# the two is cheaper than staying up, which needs g > (2 + 2p) / p for a gap of g
+# clear columns. At a 3 column gap that means p above 2.5, and there the profile
+# stops being learnable rather than merely harder: crossing costs about -9.5 in
+# shaped reward against +2 of progress, so the agent correctly concludes crossing
+# is bad and five seeds never solved it. A wider board at a low penalty is the
+# route to a two crossing course; see docs for the measured numbers.
+
+grid_size: 8
+num_drones: 1
+terrain: ridge
+ridges: 1
+low_obstacle_ratio: 0.65
+max_altitude: 1
+altitude_penalty: 0.5
+max_steps: 40
+reward_shaping: true
+shaping_potential: terrain
+fixed_layout: true
+
+safety:
+  geofence_margin: 0
+  min_separation: 0

--- a/src/agents/ppo_agent.py
+++ b/src/agents/ppo_agent.py
@@ -75,7 +75,8 @@ class PPOAgent:
     - save(path)/load(path) -> persist model weights
     """
 
-    def __init__(self, env, lr=3e-4, gamma=0.99, eps_clip=0.2, epochs=3, action_masking=None):
+    def __init__(self, env, lr=3e-4, gamma=0.99, eps_clip=0.2, epochs=3, action_masking=None,
+                 batch_episodes=None):
         self.env = env
         # Invalid action masking. The observation already reports which moves are
         # blocked, so a drone should never have to walk into a wall to find out.
@@ -90,6 +91,16 @@ class PPOAgent:
         self.gamma = gamma       # discount factor
         self.eps_clip = eps_clip # PPO clipping parameter
         self.epochs = epochs     # policy update iterations
+        # How many episodes to gather before updating. One is the smallest batch
+        # PPO can run on and it shows: advantages get normalised over a single
+        # rollout, three epochs of gradient steps are taken on it, and it is
+        # thrown away. Across tens of thousands of updates that random-walks the
+        # policy rather than improving it. Measured on the four drone flight
+        # profile, longer training made things steadily worse, solving 3 seeds of
+        # 5 at 8000 episodes, 1 at 20000 and 0 at 40000.
+        if batch_episodes is None:
+            batch_episodes = int(getattr(env, "config", {}).get("batch_episodes", 1))
+        self.batch_episodes = max(1, int(batch_episodes))
 
         # One row of features per drone, and the same move set for each. The
         # policy weights are shared across drones: a single trunk is applied to
@@ -103,6 +114,7 @@ class PPOAgent:
         # network sees.
         self._grid = float(getattr(env, "grid_size", 1) or 1)
         self._horizon = float(getattr(env, "max_steps", 1) or 1)
+        self._ceiling = float(max(1, getattr(env, "max_altitude", 0) or 1))
 
         # Two extra inputs: the offset from the drone to its own goal. See
         # _features for why that is worth more than it looks.
@@ -134,10 +146,15 @@ class PPOAgent:
         so the first layer was dominated by whichever number happened to be
         largest, and the step counter drowned out the sensors.
         """
-        arr = np.atleast_2d(np.asarray(state, dtype=np.float32))
+        arr = np.atleast_2d(np.asarray(state, dtype=np.float32)).copy()
         x, y = arr[..., 0], arr[..., 1]
         gx, gy = arr[..., 2], arr[..., 3]
         steps = arr[..., 4]
+        # Column 13 is altitude, a count rather than a flag, so it is scaled like
+        # the coordinates. Left raw it would grow with the ceiling and start
+        # outweighing the sensors, which is the same failure the step counter had.
+        if arr.shape[-1] >= 14:
+            arr[..., 13] = arr[..., 13] / self._ceiling
         flags = arr[..., 5:]
 
         out = np.concatenate(
@@ -160,19 +177,52 @@ class PPOAgent:
         )
 
     def _mask_probs(self, state, probs):
-        """Zero out moves the observation already reports as blocked.
+        """Zero out moves the observation already reports as impossible.
 
-        Observation columns 5 to 8 are blocked_up, blocked_down, blocked_left
-        and blocked_right, matching action indices 1 to 4. Hover is index 0 and
-        is always legal, so the renormalised distribution can never be empty.
+        Columns 5 to 8 are blocked_up, blocked_down, blocked_left, blocked_right
+        and match action indices 1 to 4. Columns 18 and 19 say whether climbing
+        and descending are legal, matching action indices 5 and 6. Hover is index
+        0 and is always legal, so the renormalised distribution is never empty.
+
+        What is deliberately NOT masked is the clearance group at columns 14 to
+        17, which marks a neighbour that is blocked from the current altitude but
+        reachable after climbing. Masking those would delete the decision this
+        whole feature exists to pose: go over, or go around.
         """
         if not self.action_masking:
             return probs
-        flags = torch.as_tensor(np.atleast_2d(np.asarray(state))[..., 5:9], dtype=probs.dtype)
+        arr = np.atleast_2d(np.asarray(state))
         mask = torch.ones_like(probs)
-        mask[..., 1:5] = 1.0 - flags.reshape(mask[..., 1:5].shape)
+
+        planar = torch.as_tensor(arr[..., 5:9], dtype=probs.dtype)
+        mask[..., 1:5] = 1.0 - planar.reshape(mask[..., 1:5].shape)
+
+        # Older observations stop before the vertical pair; those environments
+        # have no third dimension, so there is nothing to mask.
+        if arr.shape[-1] >= 20:
+            vertical = torch.as_tensor(arr[..., 18:20], dtype=probs.dtype)
+            mask[..., 5:7] = 1.0 - vertical.reshape(mask[..., 5:7].shape)
+
         masked = probs * mask
-        return masked / masked.sum(dim=-1, keepdim=True).clamp_min(1e-8)
+        total = masked.sum(dim=-1, keepdim=True)
+
+        # Renormalising by a clamped floor is wrong whenever the surviving mass
+        # falls below it. A confident policy puts nearly all its weight on one
+        # action; when the mask removes exactly that action the legal remainder
+        # can be far under any fixed epsilon, and dividing by the floor instead
+        # of the true sum leaves a row that is not a distribution at all. Torch
+        # renormalises inside Categorical, so nothing crashes and the policy
+        # keeps acting, which is precisely why this survived unnoticed until the
+        # integrity validator reported the drift during a fleet run.
+        #
+        # Underflow all the way to zero is the sharper failure: the row becomes
+        # all zeros and cannot be sampled from.
+        #
+        # Where the policy has no usable opinion left, spread the choice evenly
+        # over whatever is still legal. That is the honest reading of the state,
+        # and every row stays a real distribution.
+        legal = mask.sum(dim=-1, keepdim=True).clamp_min(1.0)
+        return torch.where(total > 1e-8, masked / total.clamp_min(1e-8), mask / legal)
 
     def _guard_probs(self, probs, value):
         """Report a non-finite policy output as drift before it can crash."""
@@ -219,23 +269,23 @@ class PPOAgent:
         """
         Train the PPO agent for a number of episodes.
 
-        Every quantity below is per drone, shape ``(timesteps, num_drones)``,
-        rather than one number per timestep. That distinction is the difference
-        between a fleet that coordinates and one that cannot: with a single
-        shared advantage, a drone is credited for outcomes it had no part in and
-        blamed for failures it did not cause, so its gradient is mostly other
-        drones' noise. A single drone is the degenerate case and is unaffected.
+        Episodes are gathered into a batch of ``batch_episodes`` before the
+        policy is updated. Every per-timestep quantity below is per drone, shape
+        ``(timesteps, num_drones)``, rather than one number per timestep: with a
+        single shared advantage a drone is credited for outcomes it had no part
+        in and blamed for failures it did not cause, so its gradient is mostly
+        other drones' noise. A single drone is the degenerate case, unaffected.
 
         The policy itself is shared across drones. Each drone sees only its own
         observation row and contributes its own transitions, which is parameter
         sharing with independent credit.
         """
+        pending = []
         for ep in range(num_episodes):
             state, _ = self.env.reset()
             log_probs, rewards, states, actions = [], [], [], []
             terminated, truncated = False, False
 
-            # Rollout one episode
             while not (terminated or truncated):
                 action, log_prob = self.select_action(state)
                 next_state, reward, terminated, truncated, info = self.env.step(action)
@@ -252,16 +302,34 @@ class PPOAgent:
                 actions.append(action)
                 rewards.append(per_drone)
                 log_probs.append(log_prob)
-
                 state = next_state
 
-            # Discounted returns, computed down each drone's own timeline.
+            episode_reward = float(np.array(rewards).sum())
+            # Declared in utils/metrics.py and, until now, never written to, so
+            # the Grafana training-reward panel had no series behind it.
+            TRAINING_REWARD.observe(episode_reward)
+            print(f"Episode {ep+1}, total reward={episode_reward:.2f}")
+
+            # Discounted returns run down each drone's own timeline, and must be
+            # computed per episode: a batch holds several, and carrying a return
+            # across the boundary would credit one episode's actions with the
+            # next one's outcome.
             rewards_t = torch.tensor(np.array(rewards), dtype=torch.float32)
             discounted = torch.zeros_like(rewards_t)
             running = torch.zeros(rewards_t.shape[1])
             for t in reversed(range(rewards_t.shape[0])):
                 running = rewards_t[t] + self.gamma * running
                 discounted[t] = running
+
+            pending.append((states, actions, log_probs, discounted))
+            if len(pending) < self.batch_episodes and ep < num_episodes - 1:
+                continue
+
+            states_np = np.array([s for e in pending for s in e[0]], dtype=np.float32)
+            actions_t = torch.tensor(np.array([a for e in pending for a in e[1]]), dtype=torch.long)
+            old_log_probs = torch.stack([lp for e in pending for lp in e[2]])
+            discounted = torch.cat([e[3] for e in pending], dim=0)
+            pending = []
 
             # Normalize returns -> improves training stability.
             # Only when there are at least two samples. The unbiased std of a
@@ -274,13 +342,7 @@ class PPOAgent:
             if discounted.numel() > 1:
                 discounted = (discounted - discounted.mean()) / (discounted.std() + 1e-8)
 
-            # Policy update for several epochs
             for _ in range(self.epochs):
-                states_np = np.array(states, dtype=np.float32)
-                actions_t = torch.tensor(np.array(actions), dtype=torch.long)
-                old_log_probs = torch.stack(log_probs)
-
-                # Forward pass
                 probs, values = self.policy(self._features(states_np))
                 # The same mask must be applied here. Sampling from a masked
                 # distribution and then scoring those actions against an
@@ -305,29 +367,18 @@ class PPOAgent:
                 if advantages.numel() > 1:
                     advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
 
-                # PPO surrogate loss
                 ratio = (new_log_probs - old_log_probs.detach()).exp()
                 surr1 = ratio * advantages
                 surr2 = torch.clamp(ratio, 1 - self.eps_clip, 1 + self.eps_clip) * advantages
-
-                # Value loss (MSE)
                 value_loss = (discounted - state_values) ** 2
 
-                # Total loss = policy + value - entropy
                 loss = -torch.min(surr1, surr2).mean() \
                        + 0.5 * value_loss.mean() \
                        - 0.01 * entropy
 
-                # Gradient update
                 self.optimizer.zero_grad()
                 loss.backward()
                 self.optimizer.step()
-
-            episode_reward = float(rewards_t.sum())
-            # Declared in utils/metrics.py and, until now, never written to, so
-            # the Grafana training-reward panel had no series behind it.
-            TRAINING_REWARD.observe(episode_reward)
-            print(f"Episode {ep+1}, total reward={episode_reward:.2f}")
 
     def save(self, path):
         """Save model weights to disk."""

--- a/src/env/drone_env.py
+++ b/src/env/drone_env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from collections import deque
 from typing import Tuple, Dict, Any
 
 import numpy as np
@@ -28,10 +29,21 @@ from safety_controller import SafetyController
 # occupancy is reported as information the policy can weigh, never as a
 # constraint it cannot violate.
 _BASE_FEATURES = 5
-_STATIC_FLAGS = 4       # wall or obstacle: masked
+_STATIC_FLAGS = 4       # impassable at my current altitude: masked
 _PEER_FLAGS = 4         # another drone right now: observed only
-_SENSOR_FLAGS = _STATIC_FLAGS + _PEER_FLAGS
-_FEATURES_PER_DRONE = _BASE_FEATURES + _SENSOR_FLAGS
+_ALTITUDE_FEATURES = 1  # my own altitude
+_CLEAR_FLAGS = 4        # blocked now, but passable if I climb: observed only
+_VERTICAL_FLAGS = 2     # climb and descend legality: masked
+_FEATURES_PER_DRONE = (
+    _BASE_FEATURES + _STATIC_FLAGS + _PEER_FLAGS
+    + _ALTITUDE_FEATURES + _CLEAR_FLAGS + _VERTICAL_FLAGS
+)
+
+# Obstacle heights. A drone occupies a cell only when its altitude is at least
+# the cell's height, so height is literally how high you must fly to pass.
+_CLEAR = 0    # open ground
+_LOW = 1      # low enough to fly over
+_TALL = 2     # taller than any drone can climb
 
 
 class DroneEnv(gym.Env):
@@ -67,6 +79,10 @@ class DroneEnv(gym.Env):
         self.step_penalty: float = float(self.config.get("step_penalty", 1.0))
         self.collision_penalty: float = float(self.config.get("collision_penalty", 2.0))
         self.arrival_bonus: float = float(self.config.get("arrival_bonus", 10.0))
+        # Flying has to cost something. Climbing once and staying up would
+        # otherwise make every low obstacle free, and the choice between going
+        # over and going around would stop being a choice.
+        self.altitude_penalty: float = float(self.config.get("altitude_penalty", 0.5))
         self.completion_bonus: float = float(self.config.get("completion_bonus", 50.0))
         # A fixed layout makes the task stationary: the same starts and goals
         # every episode. Random placement re-poses the problem on every reset,
@@ -74,6 +90,27 @@ class DroneEnv(gym.Env):
         # works at all. Off by default; the demo profile turns it on.
         self.fixed_layout: bool = bool(self.config.get("fixed_layout", False))
         self.shaping_gamma: float = float(self.config.get("shaping_gamma", 0.99))
+        # Which distance the shaping potential measures. "manhattan" ignores
+        # terrain completely, which is fine on an open board and actively
+        # misleading once walls exist: it points a drone straight at a barrier
+        # and never credits the climb that gets it across. "terrain" measures
+        # the real walking distance, treating anything the drone could fly over
+        # as passable. That is a relaxation of the task, not a solution to it:
+        # it says which way the goal is, and still leaves the policy to work out
+        # when climbing is worth paying for.
+        self.shaping_potential: str = str(self.config.get("shaping_potential", "manhattan"))
+        # How high a drone may climb, and what share of obstacles are low enough
+        # to clear. Both default to the flat world, so every existing config
+        # keeps its exact behaviour: no climbing, and every obstacle solid.
+        self.max_altitude: int = int(self.config.get("max_altitude", 0))
+        self.low_obstacle_ratio: float = float(self.config.get("low_obstacle_ratio", 0.0))
+        # Terrain layout. Scattered obstacles almost never force a choice about
+        # altitude: measured on one such board the trained drone reached the goal
+        # at the true optimum having never once climbed, because a clear ground
+        # route existed. A ridge puts a barrier between start and goal on purpose,
+        # so going over and going around are the only two options.
+        self.terrain: str = str(self.config.get("terrain", "scatter"))
+        self.ridges: int = max(1, int(self.config.get("ridges", 1)))
 
         # Per drone: [x, y, goal_x, goal_y, steps_remaining,
         #             blocked_up, blocked_down, blocked_left, blocked_right,
@@ -89,8 +126,11 @@ class DroneEnv(gym.Env):
                 self.grid_size - 1,
                 self.grid_size - 1,
                 self.max_steps,
-                1.0, 1.0, 1.0, 1.0,   # blocked_up/down/left/right
-                1.0, 1.0, 1.0, 1.0,   # peer_up/down/left/right
+                1.0, 1.0, 1.0, 1.0,          # blocked_up/down/left/right
+                1.0, 1.0, 1.0, 1.0,          # peer_up/down/left/right
+                max(1.0, float(self.max_altitude)),   # own altitude
+                1.0, 1.0, 1.0, 1.0,          # clearable_up/down/left/right
+                1.0, 1.0,                    # blocked_climb, blocked_descend
             ],
             dtype=np.float32,
         )
@@ -100,9 +140,15 @@ class DroneEnv(gym.Env):
             dtype=np.float32,
         )
 
-        # One move per drone: 0 hover, 1 up, 2 down, 3 left, 4 right.
-        self.action_space = spaces.MultiDiscrete([5] * self.num_drones)
-        self.action_map = {0: "hover", 1: "up", 2: "down", 3: "left", 4: "right"}
+        # One move per drone. The vertical pair exists whatever max_altitude is,
+        # so the action space has a single shape; when climbing is disabled they
+        # are simply always masked out. A conditional space would leak into the
+        # network shape, saved weights and every test.
+        self.action_space = spaces.MultiDiscrete([7] * self.num_drones)
+        self.action_map = {
+            0: "hover", 1: "up", 2: "down", 3: "left", 4: "right",
+            5: "climb", 6: "descend",
+        }
 
         self.validator = IntegrityValidator(self.action_space, self.observation_space)
         # The validators report; this one refuses. It is the only component here
@@ -110,12 +156,38 @@ class DroneEnv(gym.Env):
         self.safety = SafetyController(self.grid_size, self.config.get("safety"))
 
         self.positions = np.zeros((self.num_drones, 2), dtype=np.float32)
+        self.altitudes = np.zeros(self.num_drones, dtype=np.int32)
         # Which drones have ever reached their goal this episode, so the arrival
         # bonus pays once rather than every step the drone sits there.
         self._reached = np.zeros(self.num_drones, dtype=bool)
+        self._distance_cache: Dict[int, Any] = {}
         self.goals = np.zeros((self.num_drones, 2), dtype=np.float32)
         self.steps = 0
-        self.obstacles = np.zeros((self.grid_size, self.grid_size), dtype=bool)
+        self.heights = np.zeros((self.grid_size, self.grid_size), dtype=np.int32)
+
+    @property
+    def obstacles(self) -> np.ndarray:
+        """Any cell that is not open ground, as the old boolean grid.
+
+        Kept because placement and most callers only ever asked "is something
+        here", and because a config that knows nothing about heights should
+        behave exactly as it always did.
+
+        Returned read-only on purpose. A derived array cannot be written through:
+        ``env.obstacles[2, 2] = True`` would build a temporary, set a bit on it
+        and discard it, changing nothing and reporting nothing. Marking it
+        unwritable turns that into an immediate error instead of a test that
+        quietly stops testing what it names. Write to ``heights`` instead, which
+        is the real terrain and can say how tall an obstacle is.
+        """
+        derived = self.heights > _CLEAR
+        derived.flags.writeable = False
+        return derived
+
+    @obstacles.setter
+    def obstacles(self, value) -> None:
+        # Assigning booleans yields the flat world: every obstacle solid.
+        self.heights = (np.asarray(value).astype(bool)).astype(np.int32) * _TALL
 
     # ------------------------------------------------------------------
     # Utility methods
@@ -139,12 +211,80 @@ class DroneEnv(gym.Env):
                     data[key.strip()] = float(value) if "." in value else int(value)
             return data
 
-    def _generate_obstacles(self) -> np.ndarray:
-        """Draw a fresh obstacle grid from the seeded RNG."""
-        grid = np.zeros((self.grid_size, self.grid_size), dtype=bool)
+    def _generate_heights(self) -> np.ndarray:
+        """Draw a fresh obstacle-height grid from the seeded RNG.
+
+        With ``low_obstacle_ratio`` at zero every obstacle is solid, which is the
+        flat world the earlier configs describe. Above zero, that share of them
+        become low enough to fly over, and the drone has a real choice between
+        climbing and detouring.
+        """
+        heights = np.zeros((self.grid_size, self.grid_size), dtype=np.int32)
+        if self.terrain == "ridge":
+            return self._generate_ridge(heights)
         if self.obstacle_density <= 0:
-            return grid
-        return self.np_random.random((self.grid_size, self.grid_size)) < self.obstacle_density
+            return heights
+        occupied = self.np_random.random((self.grid_size, self.grid_size)) < self.obstacle_density
+        low = self.np_random.random((self.grid_size, self.grid_size)) < self.low_obstacle_ratio
+        heights[occupied] = _TALL
+        heights[occupied & low] = _LOW
+        return heights
+
+    def _ridge_columns(self) -> list:
+        """Evenly spaced barrier columns, with clear ground on both outsides."""
+        n = self.ridges
+        return [int(round(self.grid_size * (k + 1) / (n + 1))) for k in range(n)]
+
+    def _generate_ridge(self, heights: np.ndarray) -> np.ndarray:
+        """Barriers across the board, mostly low, partly solid.
+
+        Each wall spans the full height, so a drone travelling from the low-x
+        side to the high-x side has to cross every one of them and cannot reach
+        its goal without deciding how.
+
+        Solid segments stop climbing from collapsing into a single reflex. Over a
+        low span flying is cheap; at a solid one the only answer is to go around,
+        so the drone has to read the terrain rather than learn one habit.
+
+        With more than one wall the interesting question moves to the gap between
+        them: hold altitude across it, or drop to the ground and climb again. That
+        is a genuine trade rather than a flourish, and which way it goes is set by
+        altitude_penalty against the width of the gap. See _describe_economics.
+        """
+        for mid in self._ridge_columns():
+            for y in range(self.grid_size):
+                solid = self.np_random.random() >= self.low_obstacle_ratio
+                heights[mid, y] = _TALL if solid else _LOW
+            # One guaranteed low cell per wall, so the board stays crossable by
+            # climbing even when every random draw came up solid.
+            heights[mid, int(self.np_random.integers(0, self.grid_size))] = _LOW
+        return heights
+
+    def describe_economics(self) -> str:
+        """Whether dropping between two walls is cheaper than staying airborne.
+
+        Crossing a gap of ``g`` clear columns and stepping onto the next wall
+        costs ``(g + 1)(1 + p)`` if altitude is held. Dropping costs one airborne
+        step onto the first gap cell, a descent, ``g - 1`` ground steps, a climb,
+        and an airborne step onto the wall: ``3(1 + p) + g``. Descending wins
+        exactly when ``g > (2 + 2p) / p``.
+
+        The three ``(1 + p)`` terms are the part that is easy to get wrong. An
+        earlier version of this counted only two and reported that dropping was
+        optimal on a board where the shortest path plainly held altitude, so the
+        helper contradicted the search that scored the runs.
+        """
+        p = self.altitude_penalty
+        if p <= 0:
+            return "altitude is free, so the drone should climb once and stay up"
+        cols = self._ridge_columns()
+        if len(cols) < 2:
+            return "one wall, so there is no gap to decide about"
+        gap = cols[1] - cols[0] - 1
+        need = (2 + 2 * p) / p
+        verdict = "drop and re-climb" if gap > need else "stay airborne"
+        return (f"gap {gap} columns, altitude_penalty {p}, threshold {need:.1f} "
+                f"-> optimal is to {verdict}")
 
     def _free_cells(self) -> np.ndarray:
         """Every cell not holding an obstacle, as an (n, 2) array."""
@@ -161,6 +301,25 @@ class DroneEnv(gym.Env):
         free = self._free_cells()
         # Never spawn a drone somewhere the geofence would immediately trap it.
         free = np.array([c for c in free if self.safety.in_geofence(int(c[0]), int(c[1]))])
+
+        if self.terrain == "ridge":
+            # Straddle the barrier explicitly. The generic split sorts free cells
+            # and halves them, which has no idea a wall exists: on an eight wide
+            # board it put the goal one column short of the ridge, on the same
+            # side as the start, and the drone reached it without ever meeting
+            # the terrain the profile was built to pose.
+            cols = self._ridge_columns()
+            left = np.array([c for c in free if c[0] < cols[0]])
+            right = np.array([c for c in free if c[0] > cols[-1]])
+            if len(left) < self.num_drones or len(right) < self.num_drones:
+                raise ValueError("ridge terrain needs room on both sides of the wall")
+            lo = np.lexsort((left[:, 1], left[:, 0]))
+            ro = np.lexsort((right[:, 1], right[:, 0]))
+            starts = left[lo][np.linspace(0, len(left) - 1, self.num_drones).astype(int)]
+            goals = right[ro][np.linspace(0, len(right) - 1, self.num_drones).astype(int)]
+            self.positions = starts.astype(np.float32)
+            self.goals = goals.astype(np.float32)
+            return
 
         if self.fixed_layout:
             # Deterministic and reproducible: the first free cells become starts,
@@ -192,15 +351,26 @@ class DroneEnv(gym.Env):
         self.goals = picks[self.num_drones :].astype(np.float32)
 
     def _occupied(self) -> set:
-        return {(int(p[0]), int(p[1])) for p in self.positions}
+        # Altitude is part of the key. Two drones sharing a column at different
+        # heights are not in conflict, which is both physically true and the
+        # thing that lets one drone pass over another that is stuck.
+        return {(int(p[0]), int(p[1]), int(a))
+                for p, a in zip(self.positions, self.altitudes)}
 
-    def _is_obstacle(self, x: int, y: int) -> bool:
+    def _is_obstacle(self, x: int, y: int, altitude: int = 0) -> bool:
+        """Whether the cell blocks a drone flying at this altitude."""
         if not (0 <= x < self.grid_size and 0 <= y < self.grid_size):
             return False
-        return bool(self.obstacles[x, y])
+        return bool(self.heights[x, y] > altitude)
 
-    def _is_impassable(self, x: int, y: int, occupied: set) -> bool:
-        """Whether a cell can never be entered: off the grid, or an obstacle.
+    def _is_impassable(self, x: int, y: int, occupied: set, altitude: int = 0) -> bool:
+        """Whether a cell cannot be entered from this altitude, this turn.
+
+        Off the grid, or standing taller than the drone is currently flying. It
+        is still safe to mask on: both facts are knowable alone and true for the
+        whole turn. A cell that is only blocked because the drone is low can be
+        reached by climbing first, and that shows up in the clearance flags
+        rather than being silently permitted here.
 
         A cell holding another drone is NOT impassable. It is occupied right now
         and may be free next step, and treating the two alike is what turned the
@@ -208,21 +378,45 @@ class DroneEnv(gym.Env):
         """
         if not (0 <= x < self.grid_size and 0 <= y < self.grid_size):
             return True
-        return bool(self.obstacles[x, y])
+        return bool(self.heights[x, y] > altitude)
 
     def _sensor_flags(self, index: int, occupied: set) -> list:
-        """Eight flags for one drone, each group in action order: up, down, left, right.
+        """Fifteen flags for one drone; each group runs up, down, left, right.
 
-        The first four are static impassability and drive the action mask. The
-        last four say a neighbour is there at this instant, which the policy can
-        act on but is never forced to obey.
+        Which of them are allowed to drive the action mask is the whole point of
+        splitting them. Masking is sound only for a fact that is permanent for
+        the turn and knowable by this drone alone.
+
+        * ``blocked``   impassable from the current altitude, so masked.
+        * ``peer``      a neighbour is there this instant. Never masked; it may
+                        move, and masking it manufactures deadlock.
+        * ``clearable`` blocked now but reachable after climbing. Never masked,
+                        because the drone can choose to climb; this is the flag
+                        that makes "over or around" a decision rather than a wall.
+        * ``vertical``  whether climbing and descending are legal at all, which
+                        is knowable and permanent, so masked.
         """
         x, y = int(self.positions[index][0]), int(self.positions[index][1])
-        others = occupied - {(x, y)}
+        alt = int(self.altitudes[index])
+        others = occupied - {(x, y, alt)}
         neighbours = [(x, y + 1), (x, y - 1), (x - 1, y), (x + 1, y)]
-        static = [1.0 if self._is_impassable(nx, ny, others) else 0.0 for nx, ny in neighbours]
-        peers = [1.0 if (nx, ny) in others else 0.0 for nx, ny in neighbours]
-        return static + peers
+
+        blocked = [1.0 if self._is_impassable(nx, ny, others, alt) else 0.0
+                   for nx, ny in neighbours]
+        peers = [1.0 if (nx, ny, alt) in others else 0.0 for nx, ny in neighbours]
+        clearable = [
+            1.0 if (self._in_bounds(nx, ny)
+                    and alt < self.heights[nx, ny] <= self.max_altitude) else 0.0
+            for nx, ny in neighbours
+        ]
+        blocked_climb = 1.0 if alt >= self.max_altitude else 0.0
+        # Never descend into something you are flying over.
+        blocked_descend = 1.0 if (alt <= 0 or self.heights[x, y] > alt - 1) else 0.0
+
+        return blocked + peers + [float(alt)] + clearable + [blocked_climb, blocked_descend]
+
+    def _in_bounds(self, x: int, y: int) -> bool:
+        return 0 <= x < self.grid_size and 0 <= y < self.grid_size
 
     def _get_obs(self) -> np.ndarray:
         steps_remaining = self.max_steps - self.steps
@@ -242,15 +436,57 @@ class DroneEnv(gym.Env):
         return np.array(rows, dtype=np.float32)
 
     def _potential(self, positions) -> np.ndarray:
-        """Negative Manhattan distance to each drone's goal.
+        """Negative distance to each drone's goal, higher being closer.
 
-        Used as the shaping potential. Closer to the goal is a higher potential,
-        so moving toward it earns a small positive shaping term.
+        Ng, Harada and Russell (1999) show any potential leaves the optimal
+        policy unchanged, so the choice here is purely about how much of a hint
+        the shaping carries.
         """
-        return -np.abs(positions - self.goals).sum(axis=1)
+        if self.shaping_potential != "terrain":
+            return -np.abs(positions - self.goals).sum(axis=1)
+
+        out = np.zeros(len(positions), dtype=np.float32)
+        for i, pos in enumerate(positions):
+            field = self._distance_field(i)
+            x, y = int(pos[0]), int(pos[1])
+            out[i] = -field.get((x, y), self.grid_size * 2)
+        return out
+
+    def _distance_field(self, index: int):
+        """Steps from every cell to drone ``index``'s goal, cached per episode.
+
+        Anything the drone could fly over counts as passable, so the field knows
+        a low wall is crossable without saying how much that costs or when to
+        bother. Only genuinely solid terrain blocks it. Computed once per goal
+        because a fixed layout never moves, and the walls never move either.
+        """
+        cached = self._distance_cache.get(index)
+        if cached is not None:
+            return cached
+
+        gx, gy = int(self.goals[index][0]), int(self.goals[index][1])
+        field = {(gx, gy): 0}
+        queue = deque([(gx, gy)])
+        while queue:
+            x, y = queue.popleft()
+            for nx, ny in ((x, y + 1), (x, y - 1), (x - 1, y), (x + 1, y)):
+                if not self._in_bounds(nx, ny) or (nx, ny) in field:
+                    continue
+                if self.heights[nx, ny] > self.max_altitude:
+                    continue
+                field[(nx, ny)] = field[(x, y)] + 1
+                queue.append((nx, ny))
+
+        self._distance_cache[index] = field
+        return field
 
     def _target(self, index: int, action: int) -> Tuple[float, float]:
-        """Where one action would take one drone, clamped at the grid edge."""
+        """Where one action would take one drone, clamped at the grid edge.
+
+        Climbing and descending hold position: a turn spent changing altitude is
+        a turn not spent covering ground, and that is exactly the cost that makes
+        flying over an obstacle a trade rather than a free pass.
+        """
         x, y = float(self.positions[index][0]), float(self.positions[index][1])
         if action == 1:
             y = min(self.grid_size - 1, y + 1)
@@ -262,15 +498,31 @@ class DroneEnv(gym.Env):
             x = min(self.grid_size - 1, x + 1)
         return x, y
 
+    def _target_altitude(self, index: int, action: int) -> int:
+        """Altitude one action would leave a drone at, refusing illegal changes."""
+        alt = int(self.altitudes[index])
+        if action == 5:
+            return min(self.max_altitude, alt + 1)
+        if action == 6:
+            x, y = int(self.positions[index][0]), int(self.positions[index][1])
+            below = alt - 1
+            # Descending into the obstacle you are flying over is not a move.
+            if below < 0 or self.heights[x, y] > below:
+                return alt
+            return below
+        return alt
+
     # ------------------------------------------------------------------
     # Gym API
     # ------------------------------------------------------------------
     def reset(self, *, seed: int | None = None, options: dict | None = None) -> Tuple[np.ndarray, Dict[str, Any]]:
         super().reset(seed=seed)
-        self.obstacles = self._generate_obstacles()
+        self.heights = self._generate_heights()
         self._place()
         self.steps = 0
         self._reached = np.zeros(self.num_drones, dtype=bool)
+        self.altitudes = np.zeros(self.num_drones, dtype=np.int32)
+        self._distance_cache = {}   # goals and terrain are redrawn on reset
         return self._get_obs(), {}
 
     def step(self, action) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
@@ -286,22 +538,36 @@ class DroneEnv(gym.Env):
         if actions.size != self.num_drones:
             raise ValueError(f"expected {self.num_drones} actions, got {actions.size}")
 
-        current = [(int(p[0]), int(p[1])) for p in self.positions]
+        # Cells carry altitude. Two drones sharing a column at different heights
+        # are not in conflict, so the whole comparison below has to be in three
+        # dimensions or a drone could never pass over one that is stuck.
+        current = [(int(p[0]), int(p[1]), int(a))
+                   for p, a in zip(self.positions, self.altitudes)]
         intended = []
         collided = [False] * self.num_drones
 
-        # Pass 1: an obstacle refuses the move outright.
+        # Pass 1: terrain refuses the move outright, judged at the altitude the
+        # drone would arrive at rather than the one it left.
         for i in range(self.num_drones):
-            tx, ty = self._target(i, int(actions[i]))
-            if self._is_obstacle(int(tx), int(ty)):
+            act = int(actions[i])
+            tx, ty = self._target(i, act)
+            talt = self._target_altitude(i, act)
+            if self._is_obstacle(int(tx), int(ty), talt):
                 intended.append(current[i])
                 collided[i] = True
             else:
-                intended.append((int(tx), int(ty)))
+                intended.append((int(tx), int(ty), talt))
 
-        # The Safety Controller arbitrates before drones are compared with each
-        # other, so a move it refuses never reaches conflict resolution at all.
-        intended, veto_reasons = self.safety.review(current, intended)
+        # The Safety Controller reasons in the plane, so it is handed plan-view
+        # cells and its refusals are mapped back onto the full move. A refused
+        # drone holds its altitude too; being sent up or down by a rule that
+        # never considered height would be a decision nobody made.
+        plan_current = [(c[0], c[1]) for c in current]
+        plan_intended = [(t[0], t[1]) for t in intended]
+        reviewed, veto_reasons = self.safety.review(plan_current, plan_intended)
+        for idx, cell in enumerate(reviewed):
+            if cell != plan_intended[idx]:
+                intended[idx] = current[idx]
         for idx in veto_reasons:
             collided[idx] = True
 
@@ -335,9 +601,13 @@ class DroneEnv(gym.Env):
             if not changed:
                 break
 
-        self.positions = np.array(intended, dtype=np.float32)
+        self.positions = np.array([(t[0], t[1]) for t in intended], dtype=np.float32)
+        self.altitudes = np.array([t[2] for t in intended], dtype=np.int32)
 
-        at_goal = np.all(self.positions == self.goals, axis=1)
+        # Arriving means landing on the goal, not hovering above it. Without the
+        # altitude term a drone could park in the air over its target and count
+        # as home, which is neither what a delivery is nor what the picture shows.
+        at_goal = np.all(self.positions == self.goals, axis=1) & (self.altitudes == 0)
 
         # A drone standing on its goal earns nothing further. Paying it every
         # step made camping an income stream, and because the episode ends only
@@ -347,6 +617,10 @@ class DroneEnv(gym.Env):
         # under the old reward was to strand one drone deliberately. The agent
         # was not failing to learn that; it was learning it correctly.
         rewards = np.where(collided, -self.collision_penalty, -self.step_penalty)
+        # Height costs fuel. Without this a drone climbs once, treats every low
+        # obstacle as absent for the rest of the episode, and the choice between
+        # going over and going around stops existing.
+        rewards = rewards - self.altitude_penalty * self.altitudes
         rewards = np.where(at_goal, 0.0, rewards)
 
         # Arrival pays once, on the step a drone first reaches its goal. Leaving
@@ -361,7 +635,11 @@ class DroneEnv(gym.Env):
             # without redefining what a good route is. A sparse +10 at the goal
             # is almost never stumbled upon on a large grid, which is why an
             # unshaped run looks like it is not learning at all.
-            before = self._potential(np.array(current, dtype=np.float32))
+            # Plan coordinates only. The potential measures ground distance to
+            # the goal, and cells now carry altitude as a third element.
+            before = self._potential(
+                np.array([(c[0], c[1]) for c in current], dtype=np.float32)
+            )
             after = self._potential(self.positions)
             rewards = rewards + self.shaping_gamma * after - before
 
@@ -384,7 +662,11 @@ class DroneEnv(gym.Env):
         truncated = bool(self.steps >= self.max_steps)
 
         obs = self._get_obs()
-        info: Dict[str, Any] = {"at_goal": int(at_goal.sum()), "rewards": per_drone}
+        info: Dict[str, Any] = {
+            "at_goal": int(at_goal.sum()),
+            "rewards": per_drone,
+            "altitudes": [int(a) for a in self.altitudes],
+        }
         if any(collided):
             info["collisions"] = int(sum(collided))
         if veto_reasons:
@@ -401,19 +683,23 @@ class DroneEnv(gym.Env):
         """Draw the grid as text.
 
         ``metadata`` has always advertised a human render mode without providing
-        one. Letters are drones, digits are their goals, and ``#`` is an
-        obstacle. Row order is flipped so y increases upward, which is what the
-        coordinates say and not what list order gives you.
+        one. Letters are drones, digits are their goals, ``o`` is an obstacle low
+        enough to fly over and ``#`` is one that is not. Row order is flipped so
+        y increases upward, which is what the coordinates say and not what list
+        order gives you.
         """
         grid = [["." for _ in range(self.grid_size)] for _ in range(self.grid_size)]
         for x in range(self.grid_size):
             for y in range(self.grid_size):
-                if self.obstacles[x, y]:
-                    grid[y][x] = "#"
+                height = int(self.heights[x, y])
+                if height > _CLEAR:
+                    grid[y][x] = "o" if height <= self.max_altitude else "#"
         for i, (gx, gy) in enumerate(self.goals.astype(int)):
             grid[gy][gx] = str(i % 10)
         for i, (x, y) in enumerate(self.positions.astype(int)):
-            grid[y][x] = chr(ord("A") + i % 26)
+            # Airborne drones render lowercase, so altitude is visible in text.
+            letter = chr(ord("A") + i % 26)
+            grid[y][x] = letter.lower() if self.altitudes[i] > 0 else letter
         return "\n".join(" ".join(row) for row in reversed(grid))
 
     def close(self):

--- a/tests/test_learning_fixes.py
+++ b/tests/test_learning_fixes.py
@@ -110,7 +110,7 @@ def test_render_draws_drones_goals_and_obstacles(tmp_path):
     taken |= {(int(x), int(y)) for x, y in env.goals}
     free = next((x, y) for x in range(env.grid_size) for y in range(env.grid_size)
                 if (x, y) not in taken)
-    env.obstacles[free] = True
+    env.heights[free] = 2
 
     art = env.render()
     rows = art.splitlines()
@@ -134,3 +134,69 @@ def test_demo_runs_end_to_end(capsys):
     assert "WHAT THIS DOES NOT SHOW" in out
     assert "conflicting moves refused" in out
     assert "Drones sharing a cell at any point: 0" in out
+
+
+def test_masking_a_confident_policy_still_yields_a_distribution():
+    """The mask must never return a row that fails to sum to 1.
+
+    Renormalising by a clamped floor is wrong whenever the surviving mass falls
+    below it. A trained policy puts nearly all its weight on one action, and when
+    the mask removes exactly that action the legal remainder can sit far under
+    any fixed epsilon. Dividing by the floor rather than the true sum then leaves
+    something that is not a distribution.
+
+    This is not hypothetical. It was found by the repository's own integrity
+    validator reporting probability drift partway through a four drone flight
+    run, having gone unnoticed because torch renormalises inside Categorical, so
+    the policy kept acting and nothing ever raised.
+    """
+    import numpy as np
+    import torch
+
+    from agents.ppo_agent import PPOAgent
+    from env.drone_env import DroneEnv
+
+    env = DroneEnv("configs/fly-fleet.yaml")
+    env.reset(seed=7)
+    agent = PPOAgent(env, action_masking=True)
+
+    width = env.observation_space.shape[-1]
+    obs = np.zeros((1, width), dtype=np.float32)
+    obs[0, 5:9] = [0, 0, 1, 0]      # only "left" is blocked
+    obs[0, 18:20] = [1, 1]          # neither climbing nor descending is legal
+
+    confident = torch.full((1, 7), 1e-12)
+    confident[0, 3] = 1.0 - 6e-12   # and "left" is exactly what it wants
+
+    masked = agent._mask_probs(obs, confident)
+    assert abs(float(masked.sum()) - 1.0) < 1e-5
+    assert float(masked[0, 3]) == 0.0, "a masked action keeps zero probability"
+
+
+def test_masking_survives_total_probability_underflow():
+    """A row that underflows to exactly zero must still be samplable.
+
+    The failure above has a sharper form: when the legal mass reaches zero the
+    old renormalisation produced an all-zero row, which Categorical cannot sample
+    from at all. Falling back to a uniform choice over the legal actions is the
+    honest reading, since the policy has no usable opinion left.
+    """
+    import numpy as np
+    import torch
+    from torch.distributions import Categorical
+
+    from agents.ppo_agent import PPOAgent
+    from env.drone_env import DroneEnv
+
+    env = DroneEnv("configs/fly-fleet.yaml")
+    env.reset(seed=7)
+    agent = PPOAgent(env, action_masking=True)
+
+    width = env.observation_space.shape[-1]
+    obs = np.zeros((1, width), dtype=np.float32)
+    obs[0, 18:20] = [1, 1]
+
+    masked = agent._mask_probs(obs, torch.zeros((1, 7)))
+    assert abs(float(masked.sum()) - 1.0) < 1e-5
+    assert not bool(torch.isnan(masked).any())
+    Categorical(masked).sample()    # must not raise

--- a/tests/test_multi_drone.py
+++ b/tests/test_multi_drone.py
@@ -24,7 +24,7 @@ def pair(tmp_path):
     cfg.write_text("grid_size: 8\nnum_drones: 2\nobstacle_density: 0.0\nmax_steps: 50\n")
     e = DroneEnv(str(cfg))
     e.reset(seed=0)
-    e.obstacles[:] = False
+    e.heights[:] = 0
     try:
         yield e
     finally:
@@ -35,8 +35,11 @@ def test_fleet_size_comes_from_config():
     e = DroneEnv()
     assert e.num_drones == 10
     obs, _ = e.reset(seed=0)
-    assert obs.shape == (10, 13)
-    assert list(e.action_space.nvec) == [5] * 10
+    assert obs.shape == (10, 20)
+    # Seven: hover, the four planar moves, climb and descend. The vertical
+    # pair exists whatever max_altitude is, so the space has one shape and
+    # they are simply masked out on a board with no third dimension.
+    assert list(e.action_space.nvec) == [7] * 10
     e.close()
 
 
@@ -121,7 +124,7 @@ def test_a_peer_never_removes_a_move_from_the_policy(pair):
     agent = PPOAgent(pair, action_masking=True)
 
     obs = pair._get_obs()
-    probs = torch.ones(pair.num_drones, 5) / 5.0
+    probs = torch.ones(pair.num_drones, 7) / 7.0
     masked = agent._mask_probs(obs, probs)
 
     # Action 1 is "up", the direction drone 1 currently occupies.
@@ -176,7 +179,7 @@ def test_finishing_beats_stranding_a_drone(pair):
 
     # Same board, but drone 1 held one cell short of its goal.
     pair.reset(seed=0)
-    pair.obstacles[:] = False
+    pair.heights[:] = 0
     pair.positions = np.array([[2.0, 1.0], [6.0, 7.0]], dtype=np.float32)
     pair.goals = np.array([[2.0, 1.0], [7.0, 7.0]], dtype=np.float32)
 

--- a/tests/test_obstacles.py
+++ b/tests/test_obstacles.py
@@ -35,10 +35,11 @@ def solo(tmp_path):
         e.close()
 
 
-def test_observation_is_one_row_of_thirteen_per_drone(env):
+def test_observation_is_one_row_of_twenty_per_drone(env):
     obs, _ = env.reset(seed=0)
-    # Five state values, four static blocked flags, four peer flags.
-    assert obs.shape == (env.num_drones, 13)
+    # Five state values, four blocked flags, four peer flags, altitude,
+    # four clearance flags, and the two vertical legality flags.
+    assert obs.shape == (env.num_drones, 20)
     assert env.observation_space.contains(obs)
 
 
@@ -72,8 +73,8 @@ def test_moving_into_an_obstacle_is_refused_and_costs_extra(solo):
     """Position unchanged, the step flagged, and dearer than a plain move."""
     solo.positions = np.array([[2.0, 2.0]], dtype=np.float32)
     solo.goals = np.array([[7.0, 7.0]], dtype=np.float32)
-    solo.obstacles[:] = False
-    solo.obstacles[2, 3] = True  # directly above
+    solo.heights[:] = 0
+    solo.heights[2, 3] = 2  # directly above
 
     obs, reward, terminated, truncated, info = solo.step([1])  # up
 
@@ -86,7 +87,7 @@ def test_moving_into_an_obstacle_is_refused_and_costs_extra(solo):
 def test_a_clear_move_is_not_flagged_and_costs_one(solo):
     solo.positions = np.array([[2.0, 2.0]], dtype=np.float32)
     solo.goals = np.array([[7.0, 7.0]], dtype=np.float32)
-    solo.obstacles[:] = False
+    solo.heights[:] = 0
 
     obs, reward, terminated, truncated, info = solo.step([1])  # up
 
@@ -98,8 +99,8 @@ def test_a_clear_move_is_not_flagged_and_costs_one(solo):
 def test_sensor_flags_report_obstacles_and_edges(solo):
     """The four trailing values per row are up, down, left, right."""
     solo.positions = np.array([[0.0, 0.0]], dtype=np.float32)
-    solo.obstacles[:] = False
-    solo.obstacles[0, 1] = True  # directly above the corner
+    solo.heights[:] = 0
+    solo.heights[0, 1] = 2  # directly above the corner
 
     up, down, left, right = solo._get_obs()[0][5:9]
 

--- a/tests/test_safety_controller.py
+++ b/tests/test_safety_controller.py
@@ -21,7 +21,7 @@ def _env(tmp_path, drones=2, margin=0, separation=0, grid=10):
     )
     e = DroneEnv(str(cfg))
     e.reset(seed=0)
-    e.obstacles[:] = False
+    e.heights[:] = 0
     return e
 
 


### PR DESCRIPTION
## Problem

Obstacles were binary: a cell blocked everything or nothing. The third dimension in the browser viewer carried no information at all, because there was none to carry.

## Fix

A cell has a height, a drone has an altitude, and a drone passes only where it flies at least as high as the ground stands. Two new actions, climb and descend, each cost a turn and buy no ground, which makes crossing a trade rather than a free pass.

Height also costs fuel. Altitude is free to hold once gained, so without a per-step airborne penalty a drone climbs on turn one, treats every low obstacle as absent, and the terrain stops meaning anything.

Masking follows the rule already established for peers. **Impassable at my current altitude** is masked, because it is knowable alone and true for the whole turn. **Blocked now but reachable if I climb** is only reported, never masked; masking it would delete the decision this feature exists to pose. Descending into the obstacle you are flying over is refused outright.

### The first result was a failure worth keeping

On scattered random obstacles the trained drone reached its goal **at the true optimum having never once climbed**, because a clear ground route existed the whole time. The mechanic worked and the task never asked for it.

So random terrain does not pose the question, and ridge terrain does: a wall spanning the board between every start and every goal, mostly low enough to fly over and partly solid, with **no ground route at all**.

### One drone: solved

| | value |
|---|---|
| seeds solving | **5 of 5** at 2000 episodes |
| cost | **8.5** against a Dijkstra optimum of 8.5 |
| climbs | exactly **1** |
| without flight | unreachable |

The route is right for the right reason: `right, right, right, climb, right, right, descend`. It walks to the wall on the ground, climbs only at the barrier, and lands on the far side. It did not learn to fly everywhere.

### Four drones: not solved, and the config says so

8000 episodes is where it is least unsolved. Training further makes it **worse**:

| episodes | all home | drones home | climbs |
|---|---|---|---|
| 8000 | 3 of 5 | 80% | 4.0 |
| 20000 | 1 of 5 | 70% | 3.8 |
| 40000 | 0 of 5 | 65% | 3.0 |

Single-episode updates were the obvious suspect, so batched updates are added as a knob. Batching 16 measured worse at equal episode count (20% home at 8000, 40% at 20000) because it is also a sixteenth of the gradient steps. Whether a smaller batch with proportionally more episodes wins is **unmeasured**, and is left named rather than guessed at.

## Two bugs, both found by running rather than reading

**The action mask could return a row that was not a probability distribution.** It renormalised by a clamped floor, so when a confident policy put nearly all its mass on an action the mask removed, the surviving remainder fell under that floor and dividing by it stopped normalising. Underflow to exactly zero was worse: the row became unsamplable. Torch renormalises inside `Categorical`, so nothing ever raised and the policy kept acting. **This repository's own integrity validator reported the drift partway through a fleet run**, which is the entire argument the README makes for having it.

**Deriving `obstacles` from `heights` introduced a silent one.** A computed boolean grid cannot be written through, so `env.obstacles[2, 2] = True` built a temporary, set a bit on it and discarded it. Several tests carried on asserting against terrain they had never actually placed. The property is now returned read-only, turning that into an immediate error.

## Tests

Testing taxonomy: Unit, Integration, Agent behavior (evals), Edge cases.

- [x] Unit: a low obstacle reads blocked-but-clearable from the ground and unblocked once airborne
- [x] Unit: descending into the obstacle a drone is flying over is refused
- [x] Unit: masking a confident policy whose preferred action is illegal still yields a row summing to 1
- [x] Unit: a row whose legal mass underflows to zero stays samplable, falling back to uniform over legal actions
- [x] Unit: observation is 20 features per drone and the action space is 7 wide on every profile
- [x] Integration: `obstacles` is read-only, so writing terrain through it raises instead of silently doing nothing
- [x] Agent behavior: one drone solves the ridge course on 5 of 5 seeds at the Dijkstra optimum, climbing exactly once, where no ground route exists
- [x] Agent behavior: four drones reach 3 of 5 seeds fully home at 8000 episodes and degrade thereafter, recorded in the config rather than presented as solved
- [x] Edge cases: `max_altitude: 0` reproduces the flat world exactly, with the vertical actions always masked

Quality gates: 54 tests passing, coverage 86%.