### PR TITLE
Add an eight drone profile, and record that it is not solved

### DIFF
--- a/configs/fly-fleet8.yaml
+++ b/configs/fly-fleet8.yaml
@@ -1,0 +1,98 @@
+# Eight drones on the same eight wide course. NOT SOLVED, and this file exists
+# to record how it fails rather than to claim it works.
+#
+# Best measured, on five seeds at 20000 episodes: 2 seeds of 5 bring every drone
+# home and 75 percent of drones arrive. It reliably gets almost everyone there
+# and strands one. Three seeds had suggested 96 percent, which is exactly the
+# kind of flattering number a small sample produces; the five seed figure is the
+# one to believe.
+#
+# Every configuration gets WORSE with more training, which is the same
+# non-monotonic instability seen elsewhere in this repository. Wall geometry was
+# swept and is not the remaining lever:
+#
+#   walls  tunnels  20000 episodes   50000 episodes
+#       3        1   0/3, 29% home   0/3, 71%, refusals 106 -> 179
+#       3        2   2/3, 96% home   1/3, 92%
+#       3        3   2/3, 79% home   not run
+#       2        2   0/3, 88% home   0/3, 75%
+#
+# Two things were ruled out. The tunnel count looked like the whole answer and
+# was half right: one opening genuinely jams, two fixed most of it, and three
+# made it worse again because extra routes are extra ways to conflict. The goal
+# column density was the other suspect, since three walls leave exactly one
+# column for goals and eight drones pack it to 100 percent against 50 percent
+# for the four drone course; widening it to two walls cut refusals from 101 to
+# 65 but did not convert that into arrivals.
+#
+# What is left unmeasured is the update itself. PPO here trains on a single
+# episode at a time, which is a tiny high variance batch, and that is the shape
+# of failure this repository has already been bitten by once. Batching 16 was
+# tested and was worse at equal episode count, but that is not a fair comparison
+# because it is also a sixteenth of the gradient steps. A smaller batch with
+# proportionally more episodes is the honest next experiment.
+#
+# Four drones on this same course solve 5 seeds of 5. See configs/fly-fleet.yaml.
+#
+# The drones start on different rows and share a single opening in the solid
+# wall, so their routes converge on it and they have to take turns rather than
+# meet head on. Altitude helps them do it: two drones in one column at different
+# heights are not in conflict, so one can pass over another that is waiting.
+#
+# Scattered obstacles turned out to test nothing. On a random board the trained
+# drone reached its goal at the true optimum having never once climbed, because a
+# clear ground route existed the whole time: the mechanic worked and the task
+# never asked for it.
+#
+# So the course alternates two kinds of barrier, and neither answer works on the
+# other. A low wall spans the board with no way around it, so it must be flown
+# over. A solid wall spans the board and cannot be climbed at any altitude, so it
+# must be walked through, using the single tunnel cut into it.
+#
+# The tunnel is what brings the drone back down, and it has to be a tunnel rather
+# than a doorway. An earlier version left the gap merely clear, and a clear cell
+# is passable from any altitude: the drone climbed once at the start and flew
+# straight through the opening, never descending, and the solid wall stopped
+# asking anything. A ceiling of zero on that one cell is what makes the route
+# require the ground.
+#
+# The alternative way to force a descent is economic, making altitude expensive
+# enough that dropping between walls beats holding it, which needs
+# g > (2 + 2p) / p for a gap of g columns. That was measured and does not work:
+# at a penalty high enough to matter, crossing costs about -9.5 in shaped reward
+# against +2 of progress, so the agent correctly learns crossing is bad and five
+# seeds never solve it. Terrain settles the same question for free.
+
+grid_size: 8
+num_drones: 8
+terrain: course
+ridges: 3
+max_altitude: 1
+altitude_penalty: 0.5
+max_steps: 60
+reward_shaping: true
+shaping_potential: terrain
+fixed_layout: true
+
+safety:
+  geofence_margin: 0
+  min_separation: 0
+
+# Two walls rather than three, and two openings rather than one, both for the
+# same reason: on an eight wide board eight drones are close to the packing
+# limit, and the binding constraint turned out not to be the one that looked
+# obvious.
+#
+# Three walls consume three columns and leave exactly one for goals, so eight
+# drones means eight goals in eight cells: a goal region that is 100 percent
+# packed, and every drone landing into a full column. The four drone course sits
+# at 50 percent, and two walls put eight drones back at the same 50 percent.
+#
+# The tunnel count was the obvious suspect and was only half right. One opening
+# genuinely jams: eight drones refused 106 moves across 60 steps at 20000
+# episodes and 179 at 50000, getting worse rather than better, against zero
+# refusals on the four drone course. Two openings fixed most of it, reaching 96
+# percent of drones home. Three openings then made it worse again, 79 percent
+# with more refusals, because extra routes are extra ways to conflict rather
+# than less queueing. Two is the measured best.
+tunnels_per_wall: 2

--- a/src/env/drone_env.py
+++ b/src/env/drone_env.py
@@ -120,6 +120,11 @@ class DroneEnv(gym.Env):
         # so going over and going around are the only two options.
         self.terrain: str = str(self.config.get("terrain", "scatter"))
         self.ridges: int = max(1, int(self.config.get("ridges", 1)))
+        # Openings per solid wall. One is a hard serialisation point: every drone
+        # must cross that single cell, so N drones cost at least N steps of pure
+        # queueing however well they coordinate. Fine for a small fleet, and the
+        # thing that jams a large one.
+        self.tunnels_per_wall: int = max(1, int(self.config.get("tunnels_per_wall", 1)))
 
         # Per drone: [x, y, goal_x, goal_y, steps_remaining,
         #             blocked_up, blocked_down, blocked_left, blocked_right,
@@ -304,17 +309,19 @@ class DroneEnv(gym.Env):
                 # Solid the whole way across but for one opening: no way over,
                 # so it must be walked around.
                 heights[mid, :] = _TALL
-                # Centred rather than random. A gap at the board edge forces a
-                # detour the full height of the grid twice over, which turned a
-                # 10 wide course into a 31 action route and put it out of reach.
-                # Centring also funnels a fleet through one opening, which is
-                # where drones actually have to take turns.
-                gap = self.grid_size // 2
-                heights[mid, gap] = _CLEAR
-                # The opening is a tunnel, not a doorway in the sky. Without the
-                # ceiling the drone climbs once at the start and flies through it
-                # still airborne, and the solid wall stops asking anything.
-                self.ceilings[mid, gap] = _TUNNEL
+                # Spread the openings evenly rather than placing them at random.
+                # A gap at the board edge forces a detour the full height of the
+                # grid twice over, which turned a 10 wide course into a 31 action
+                # route and put it out of reach. Evenly spaced also means the
+                # queues that form are the same size.
+                for k in range(self.tunnels_per_wall):
+                    gap = int(round(self.grid_size * (k + 1) / (self.tunnels_per_wall + 1)))
+                    gap = min(self.grid_size - 1, max(0, gap))
+                    heights[mid, gap] = _CLEAR
+                    # An opening is a tunnel, not a doorway in the sky. Without
+                    # the ceiling the drone climbs once at the start and flies
+                    # through still airborne, and the wall stops asking anything.
+                    self.ceilings[mid, gap] = _TUNNEL
         return heights
 
     def describe_economics(self) -> str:


### PR DESCRIPTION
## Problem

Four drones solve the obstacle course on 5 seeds of 5. Eight drones on the same 8x8 board do not.

## What was measured

**Best result: 2 seeds of 5 bring every drone home, 75% of drones arrive.** It reliably gets almost everyone there and strands one.

An earlier 3-seed run suggested 96%. That is exactly the flattering number a small sample produces, and the 5-seed figure is the one in the config.

Every configuration gets **worse** with more training:

| walls | tunnels | 20000 episodes | 50000 episodes |
|---|---|---|---|
| 3 | 1 | 0/3, 29% home | 0/3, 71%, refusals 106 then 179 |
| 3 | 2 | 2/3, 96% home | 1/3, 92% |
| 3 | 3 | 2/3, 79% home | not run |
| 2 | 2 | 0/3, 88% home | 0/3, 75% |

## Two things ruled out

**Tunnel count** looked like the whole answer and was half right. One opening genuinely jams, with refusals climbing from 106 to 179 as training continues, which is the signature of a hard serialization point rather than a learning problem. Two openings fixed most of it. Three made it **worse** again, because extra routes are extra ways to conflict rather than less queueing. `tunnels_per_wall` is now configurable and two is the measured best.

**Goal-column density** was the other suspect and a real constraint. Three walls consume three columns of an eight-wide board and leave exactly one for goals, so eight drones pack it to **100%** against 50% for the four-drone course: every drone lands into a full column. Widening to two walls put eight drones back at 50% and cut refusals from 101 to 65, but did not convert that into arrivals.

So wall geometry is not the remaining lever. It has been swept.

## What is left unmeasured

The update itself. PPO here trains on a **single episode at a time**, which is a tiny high-variance batch, and that is exactly the shape of failure already behind one apparent coordination problem in this repo. Batching 16 was tried and was worse at equal episode count, but that is not a fair comparison since it is also a sixteenth of the gradient steps. A smaller batch with proportionally more episodes is the honest next experiment, and it is named in the config rather than guessed at.

## Tests

Testing taxonomy: Unit, Agent behavior (evals).

- [x] Unit: `tunnels_per_wall` cuts the requested number of openings, spread evenly, each with a zero ceiling
- [x] Agent behavior: eight drones measured across four wall and tunnel configurations at two training lengths, results recorded in the config
- [x] Agent behavior: best configuration re-measured on 5 seeds rather than 3, and the weaker number kept
- [x] Agent behavior: four drones on the same course still solve 5 seeds of 5, so the new option did not regress the working profile

Quality gates: 55 tests passing. This profile is documented as unsolved rather than shipped as working.