### PR TITLE
Draw a bounced drone as bounced, so the board agrees with the count

### DIFF
--- a/configs/fly-fleet8.yaml
+++ b/configs/fly-fleet8.yaml
@@ -1,5 +1,6 @@
 # Eight drones on the same eight wide course, and the densest board here that
-# is solved: ten seeds of ten bring every drone home, in 24 steps against the
+# is solved: ten seeds of ten bring every drone home and keep it there, in 24
+# steps against the
 # best plan a central planner has found for this board, 17, with 33 refused
 # moves. Seventeen is a bound and not a proven optimum: prioritised planning is
 # incomplete and scripts/plan_optimum.py reports the best of 400 sampled

--- a/docs/sim.html
+++ b/docs/sim.html
@@ -189,13 +189,14 @@
 <div id="hud">
   <div class="stat"><div class="k">Step</div><div class="v" id="s-step">0</div></div>
   <div class="stat"><div class="k">Reward</div><div class="v" id="s-reward">0</div></div>
-  <div class="stat"><div class="k">At goal</div><div class="v accent" id="s-goal">0</div></div>
+  <div class="stat"><div class="k">Settled</div><div class="v accent" id="s-goal">0</div></div>
   <div class="stat"><div class="k">Refused</div><div class="v" id="s-refused">0</div></div>
 </div>
 
 <div id="legend" class="panel">
   <div><span class="swatch" style="background:#e8ebe9"></span>trained policy</div>
   <div><span class="swatch" style="background:#6faa85"></span>arrived at its goal</div>
+  <div><span class="swatch" style="background:#c8a06a"></span>left a goal and came back, not counted</div>
   <div><span class="swatch" style="background:#6b5f52"></span>untrained ghost</div>
   <div><span class="swatch" style="background:#2f4038;border:1px solid #6faa85"></span>low, can be flown over</div>
   <div><span class="swatch" style="background:#232d27"></span>solid, must be gone around</div>
@@ -233,6 +234,10 @@ const PALETTE = [
   0xb9c0bb, 0x8d9aa3, 0x9aa39d, 0x77848c,
 ];
 const GOAL_GREEN = 0x6faa85;
+// A drone standing on its goal that had left one earlier. It is not counted as
+// settled, so it must not be drawn like the drones that are: seven greens beside
+// a label reading six is the interface contradicting itself.
+const BOUNCED_AMBER = 0xc8a06a;
 const GHOST = 0x6b5f52;   // warm, so it never reads as a drone doing well
 
 // Flight height scales with the board. A fixed height that looked right on the
@@ -471,6 +476,24 @@ function updateOcclusion(dt) {
 }
 
 /* playback */
+
+// Which drones have left a goal they had already reached, as of each frame.
+// Derived here rather than exported: every position and altitude is already on
+// hand, and computing it locally keeps the picture and the checkpoint count
+// answering the same question at every step of the replay.
+function bounceFlags(r) {
+  const n = r.frames[0].atGoal.length;
+  const landed = new Array(n).fill(false);
+  const bounced = new Array(n).fill(false);
+  return r.frames.map(f => {
+    for (let d = 0; d < n; d++) {
+      if (landed[d] && !f.atGoal[d]) bounced[d] = true;
+      if (f.atGoal[d]) landed[d] = true;
+    }
+    return bounced.slice();
+  });
+}
+
 function frameAt(r, i) {
   const last = r.frames.length - 1;
   return r.frames[Math.max(0, Math.min(i, last))];
@@ -480,6 +503,8 @@ function paint() {
   const i = Math.max(0, Math.floor(cursor));
   const t = cursor - i;
   const a = frameAt(run, i), b = frameAt(run, i + 1);
+  const flags = run._bounce || (run._bounce = bounceFlags(run));
+  const bounced = flags[Math.max(0, Math.min(i, flags.length - 1))];
   const showGhost = el('ghost').checked && ghostRun && ghostRun !== run;
 
   for (let d = 0; d < drones.length; d++) {
@@ -493,8 +518,10 @@ function paint() {
     drones[d].rotation.y += 0.012;
 
     const home = a.atGoal[d];
-    drones[d].material.color.setHex(home ? GOAL_GREEN : PALETTE[d % PALETTE.length]);
-    drones[d].material.emissive.setHex(home ? GOAL_GREEN : PALETTE[d % PALETTE.length]);
+    const drifted = home && bounced && bounced[d];
+    const tint = home ? (drifted ? BOUNCED_AMBER : GOAL_GREEN) : PALETTE[d % PALETTE.length];
+    drones[d].material.color.setHex(tint);
+    drones[d].material.emissive.setHex(tint);
     drones[d].material.emissiveIntensity = home ? 0.75 : 0.28;
 
     stems[d].geometry.dispose();
@@ -521,7 +548,10 @@ function paint() {
 
   el('s-step').textContent = i + 1;
   el('s-reward').textContent = a.cumulative.toFixed(1);
-  el('s-goal').textContent = `${a.atGoal.filter(Boolean).length}/${S.numDrones}`;
+  // Settled, not merely standing there, so this agrees with the checkpoint
+  // label and with the colours on the board.
+  const settledNow = a.atGoal.filter((v, d) => v && !bounced[d]).length;
+  el('s-goal').textContent = `${settledNow}/${S.numDrones}`;
   el('s-refused').textContent = run.frames.slice(0, i + 1).reduce((s, f) => s + f.refused, 0);
   el('step').textContent = `${i + 1} / ${run.frames.length}`;
   el('scrub').value = i;


### PR DESCRIPTION
## Problem

- The checkpoint label counted settled drones while the board still painted every drone standing on a goal green. At 10000 episodes that showed **seven green drones beside a label reading six**, with nothing on screen to say which one did not count.
- The legend promises green means "arrived at its goal", so the picture was actively contradicting the number next to it.
- Separately, the eight drone result had been verified with a metric that scored each drone by where it stood on the final step. That check could not have detected a drone that arrived, left, and drifted back, so it was not evidence for the claim it was supporting.

## Fix

A drone that left a goal it had reached is drawn amber wherever it appears, and the live readout counts settled rather than occupying. Picture, checkpoint label, and readout now answer the same question at every frame. The flags are derived in the viewer from positions and altitudes already in the payload, so no re-export was needed.

Re-measured the eight drone result under the stricter rule rather than assuming it carried over, scoring both ways on the same ten fresh seeds:

```
old rule (standing on goal at the end): 10 seeds of 10
new rule (arrived and stayed):          10 seeds of 10
```

Zero bounces on every seed. The figure is unchanged, which is the outcome worth having, but it was not established until now.

## Tests

- [x] Manual UI sanity: 10000-episode checkpoint renders 6 green, 1 amber, 1 untinted with readout "SETTLED 6/8", matching its "1 bounced, 6/8 settled" label
- [x] Agent behavior: eight drones re-verified on 10 seeds under arrive-and-stay, 8/8 settled and 0 bounced on every seed
- [x] Regression: full suite green, 64 passed, coverage 86 percent