### PR TITLE
Say which settled is which: now, or at the end of the episode

### DIFF
--- a/docs/sim.html
+++ b/docs/sim.html
@@ -189,7 +189,7 @@
 <div id="hud">
   <div class="stat"><div class="k">Step</div><div class="v" id="s-step">0</div></div>
   <div class="stat"><div class="k">Reward</div><div class="v" id="s-reward">0</div></div>
-  <div class="stat"><div class="k">Settled</div><div class="v accent" id="s-goal">0</div></div>
+  <div class="stat"><div class="k">Settled now</div><div class="v accent" id="s-goal">0</div></div>
   <div class="stat"><div class="k">Refused</div><div class="v" id="s-refused">0</div></div>
 </div>
 
@@ -638,7 +638,12 @@ function selectScenario(idx) {
     + `<span class="mono">scripts/export_trajectory.py</span> recorded every position.`;
 
   document.querySelector('#rail .rail-label:nth-of-type(1)');
-  [...document.querySelectorAll('.rail-label')][1].textContent = `Checkpoint  ·  seed ${S.replaySeed}`;
+  // "at end" is load-bearing. This column reports the finished episode while
+  // the readout under the board reports the frame on screen, and with both
+  // merely labelled "settled" the two disagreeing looked like a defect. It was
+  // asked about three separate times before the wording changed.
+  [...document.querySelectorAll('.rail-label')][1].textContent =
+    `Checkpoint  ·  seed ${S.replaySeed}  ·  at end`;
 
   el('runs').innerHTML = '';
   S.runs.forEach((r, k) => {


### PR DESCRIPTION
## Problem

- The checkpoint column reports the finished episode; the readout under the board reports the frame currently on screen. Both were labelled "settled".
- So the two disagreeing read as a defect rather than as two answers to two different questions. At the 5000-episode checkpoint, step 32 shows 2/8 while the column shows 3/8, because the third drone does not arrive until step 36.
- Asked about three separate times. Once is a question; three times is the interface being wrong, and explaining does not fix a label.

## Fix

The readout is now "Settled now". The checkpoint column header carries "at end", so it reads `Checkpoint · seed 2 · at end`.

## Tests

- [x] Manual UI sanity: at the 5000-episode checkpoint, step 32 renders "Settled now 2/8" against the column's "3/8 settled" under a header reading "at end"
- [x] Regression: full suite green, 64 passed, coverage 86 percent