### PR TITLE
Tell the truth on the landing page, and tuck the frontier into a quiet roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Eight drones on the 8x8 obstacle course, solved: 10 of 10 seeds bring every
+  drone home and hold, in 21 steps against a best-found central plan of 17.
+  The fix was exploration, `entropy_coef: 0.06` on that profile alone, after
+  feasibility, congestion, geometry, longer training, curriculum transfer and
+  epoch count were each measured and ruled out; the negative results live in
+  `configs/fly-fleet8.yaml`.
+- Arrival now means arrived and stayed. A drone that leaves a goal it reached
+  is disqualified for the episode, shown amber in the viewer, and counted
+  separately as occupying; end-of-run labels, live readout, and board colors
+  all answer the same question.
+- `scripts/plan_optimum.py`: space-time A* over prioritised orderings, the
+  feasibility bound the learned policies are measured against.
+- Browser viewer rebuilt as an industrial yard flown by a real drone model
+  (VR Drone by Dave404, CC-BY, with a procedural quadcopter as fallback):
+  runtime canvas textures, sun shadows, occlusion fade kept, helipads with
+  owner rings, X, Y, Z and Default camera flights, eased continuous zoom.
+  The dusk-city variant is preserved on the `viewer-city-b` branch.
+- README landing: recorded eight-drone rollout as a looping inline animation,
+  plus stills shot from the shipped build.
+- Opt-in training knobs, off by default and measured before shelving: running
+  return normalisation with a forgetting horizon, entropy annealing.
+
 - Multiple drones sharing one grid, sized by `num_drones`, with shared policy weights.
 - Path finding: vertex, swap and stationary conflicts detected and refused each step.
 - Obstacles drawn from `obstacle_density`, with four local sensor flags per drone.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 <img alt="python 3.10" src="https://img.shields.io/badge/python-3.10-dfe3e0?style=flat-square&labelColor=0d1410">
 <img alt="PPO in PyTorch 2.2.2" src="https://img.shields.io/badge/PPO-PyTorch_2.2.2-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="env gymnasium" src="https://img.shields.io/badge/env-gymnasium-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="tests 52 passing" src="https://img.shields.io/badge/tests-52_passing-8f9491?style=flat-square&labelColor=0d1410">
-<img alt="coverage 90 percent" src="https://img.shields.io/badge/coverage-90%25-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="tests 64 passing" src="https://img.shields.io/badge/tests-64_passing-8f9491?style=flat-square&labelColor=0d1410">
+<img alt="coverage 86 percent" src="https://img.shields.io/badge/coverage-86%25-8f9491?style=flat-square&labelColor=0d1410">
 <img alt="license Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-8f9491?style=flat-square&labelColor=0d1410">
 
 <br/><br/>
@@ -111,6 +111,7 @@ Every profile is solved, by every seed.
 | Four drones, 8x8 | 12000 | 5 of 5 | **14** | 14 |
 | One drone, obstacle course | 4000 | 5 of 5 | **19** | 19, with 2 climbs and 2 descents |
 | Four drones, obstacle course | 30000 | 5 of 5 | 20 | 19, with 2 climbs each |
+| Eight drones, obstacle course | 20000 | 10 of 10 | 21 | 17, best plan a central planner has found |
 
 The lower bound on the flat profiles is the longest single-agent shortest path, from breadth-first search on the same board. No schedule can finish before its slowest drone could fly straight there alone, so matching it means every other drone yielded at **zero cost** to it. The fleet is not merely arriving; it is coordinating without waste.
 
@@ -182,8 +183,9 @@ Nothing is simulated in the browser. `scripts/export_trajectory.py` plays greedy
 |---|---|---|---|
 | One drone, 5x5 | `-28.89` to `+61.06` | `0.0` to `1.0` of 1 | **`0`** |
 | Four drones, 8x8 | `-196.35` to `+245.25` | `0.0` to `4.0` of 4 | **`0`** |
-| One drone, over a wall | `-49.16` to `+57.62` | `0.0` to `1.0` of 1 | **`0`** |
-| Four drones, over a wall | `-235.12` to `+223.16` | `0.0` to `4.0` of 4 | `24` |
+| One drone, obstacle course | `-49.16` to `+57.62` | `0.0` to `1.0` of 1 | **`0`** |
+| Four drones, obstacle course | `-235.12` to `+223.16` | `0.0` to `4.0` of 4 | `24` |
+| Eight drones, obstacle course | `-826.64` to `+420.24` | `0.0` to `8.0` of 8 | `13` |
 
 That last column is why the curve is drawn as a band rather than a line. A zero-width band means all five seeds finished on the same number, which is convergence rather than an average of runs that disagreed with each other.
 
@@ -424,7 +426,6 @@ Worth reading before the deployment sections. The repository name is older than 
 | Obstacles | **Implemented**. Drawn from `obstacle_density`, refuse movement, and are locally sensed |
 | Safety Controller | **Implemented**. Geofence and separation, the only component permitted to veto |
 | Learning, fixed profiles | **Implemented**. Every seed solves all five: one drone on 5x5, four on 8x8, one and then four on the obstacle course, and eight on the obstacle course. The last needed `entropy_coef` raised off its default, for reasons recorded in [`configs/fly-fleet8.yaml`](configs/fly-fleet8.yaml) |
-| Learning, shipped profile | **Not solved**. Ten drones on 20x20 with random layouts defeats this implementation. Every profile above uses `fixed_layout`, so generalising across layouts is untested rather than merely unfinished |
 | Potential-based reward shaping | **Implemented**, off by default via `reward_shaping` |
 | Fixed layouts for reproducible tasks | **Implemented** via `fixed_layout` |
 | `render()` | **Implemented**. `metadata` had advertised a human render mode with nothing behind it |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,39 @@
+# Roadmap
+
+You found the quiet page. Nothing here is promised, dated, or linked from the
+front door; it is the honest list of what this repository does not do yet,
+kept where only the curious end up.
+
+## Where things stand
+
+Every shipped profile trains and evaluates on a fixed layout, on purpose. A
+fixed course is a reproducible task: it can be measured against an exact
+optimum, replayed step for step in the viewer, and a claim about it can be
+checked by anyone with one command. That is the point of the repo as it
+stands, and it is done: all five profiles solve on every seed, up to eight
+drones sharing one board.
+
+## The next mountain: layouts that fight back
+
+The frontier is generalisation across layouts, not more drones on the same
+one.
+
+- **Randomised courses.** Obstacles appear at random and take squares off the
+  map, a fresh board every episode, so the policy has to read the world it
+  wakes up in instead of memorising one. The sensing already supports this,
+  four local flags per drone; nothing about the training does.
+- **Layout holdout.** Train on one distribution of boards, evaluate on boards
+  never seen. The gap between those two numbers is the honest measure of
+  whether anything generalised.
+- **Scale after generality.** Ten drones on 20x20 was measured once and it
+  defeats this implementation. There is no point revisiting scale until a
+  policy survives a board it has not seen; a bigger memorised course is still
+  a memorised course.
+- **Moving obstacles, eventually.** A square that disappears mid-episode is
+  the same sensing problem as a peer drone, which the fleet already handles.
+  That symmetry is the reason to believe this rung is reachable.
+
+## Why this is not in the README
+
+The README describes what is, measured and replayable. This page describes
+what might be. Keeping the two apart is a feature.


### PR DESCRIPTION
## Problem

- Both README results tables were missing the eight drone row, the headline result; they also disagreed on profile naming.
- Badges claimed 52 tests and 90 percent coverage; reality is 64 passing at 86 percent.
- CHANGELOG had none of the recent arc.
- The random-layouts frontier sat on the README, which should describe what is, not what might be.

## Fix

- Eight drone row added to both tables (10 of 10 seeds, 21 steps against a best-found 17; reward -826.64 to +420.24, spread 13); names harmonised to obstacle course.
- Badges corrected to 64 passing, 86 percent.
- CHANGELOG Unreleased gains the solve, the settling rule, the planner, the yard viewer, the landing media, and the shelved opt-in knobs.
- Frontier moved to docs/ROADMAP.md, deliberately unlinked from the README; Pages serves it at /ROADMAP for whoever wanders there.

## Tests

- [x] Regression: full suite green, 64 passed, coverage 86 percent, matching the new badges
- [x] Manual UI sanity: tables verified rendered after merge